### PR TITLE
fix: ProbeForLandlock pin to Linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,9 @@
       in
       {
         devShell = pkgs.devshell.mkShell {
+          env = [
+            { name = "GOPROXY"; value = "https://proxy.golang.org,direct"; }
+          ];
           devshell = {
             name = "sandbox-probe";
             motd = "";

--- a/pkg/tasks/baseline/environment_linux_test.go
+++ b/pkg/tasks/baseline/environment_linux_test.go
@@ -1,0 +1,16 @@
+//go:build linux
+// +build linux
+
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getHostMounts(t *testing.T) {
+	mounts, err := GetHostMounts()
+	t.Logf("Mounts found: %v", mounts)
+	assert.NoError(t, err)
+}

--- a/pkg/tasks/baseline/environment_test.go
+++ b/pkg/tasks/baseline/environment_test.go
@@ -142,8 +142,4 @@ func Test_getContainerRuntime(t *testing.T) {
 	}
 }
 
-func Test_getHostMounts(t *testing.T) {
-	mounts, err := GetHostMounts()
-	t.Logf("Mounts found: %v", mounts)
-	assert.NoError(t, err)
-}
+

--- a/pkg/tasks/baseline/landlock.go
+++ b/pkg/tasks/baseline/landlock.go
@@ -6,3 +6,7 @@ package tasks
 func ProbeLandlockSelfDepth() (int, error) {
 	return 0, nil
 }
+
+func ProbeForLandlock() (bool, error) {
+	return false, nil
+}

--- a/pkg/tasks/baseline/landlock_common.go
+++ b/pkg/tasks/baseline/landlock_common.go
@@ -1,41 +1,5 @@
 package tasks
 
-import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-)
-
 const (
 	LANDLOCK_MAX_DEPTH = 16
 )
-
-func ProbeForLandlock() (bool, error) {
-	self, err := os.Executable()
-	if err != nil {
-		return false, fmt.Errorf("failed to get self executable location: %w", err)
-	}
-
-	cmd := exec.Command(self, "probe")
-	out, err := cmd.Output()
-	if err != nil {
-		return false, err
-	}
-
-	var pd ProbeSubCmdData
-	err = json.Unmarshal(out, &pd)
-	if err != nil {
-		return false, err
-	}
-
-	if pd.LockdownDepth > LANDLOCK_MAX_DEPTH {
-		return false, fmt.Errorf("lockdown depth isn't expected to ever go beyond %d", LANDLOCK_MAX_DEPTH)
-	}
-
-	if pd.LockdownDepth == LANDLOCK_MAX_DEPTH {
-		return false, nil
-	}
-
-	return true, nil
-}

--- a/pkg/tasks/baseline/landlock_linux.go
+++ b/pkg/tasks/baseline/landlock_linux.go
@@ -1,12 +1,47 @@
+//go:build linux
+// +build linux
+
 package tasks
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
+
+func ProbeForLandlock() (bool, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return false, fmt.Errorf("failed to get self executable location: %w", err)
+	}
+
+	cmd := exec.Command(self, "probe")
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+
+	var pd ProbeSubCmdData
+	err = json.Unmarshal(out, &pd)
+	if err != nil {
+		return false, err
+	}
+
+	if pd.LockdownDepth > LANDLOCK_MAX_DEPTH {
+		return false, fmt.Errorf("lockdown depth isn't expected to ever go beyond %d", LANDLOCK_MAX_DEPTH)
+	}
+
+	if pd.LockdownDepth == LANDLOCK_MAX_DEPTH {
+		return false, nil
+	}
+
+	return true, nil
+}
 
 func ProbeLandlockSelfDepth() (int, error) {
 	// Required before landlock_restrict_self

--- a/pkg/tasks/baseline/processes_linux_test.go
+++ b/pkg/tasks/baseline/processes_linux_test.go
@@ -1,0 +1,62 @@
+//go:build linux
+// +build linux
+
+package tasks
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getRunningProcess(t *testing.T) {
+	pid := os.Getpid()
+	proc, err := GetRunningProcess(pid)
+
+	require.NoError(t, err, "getRunningProcess should not return error for current process")
+	require.NotNil(t, proc, "Process should not be nil")
+	assert.NotEmpty(t, proc.Command, "Command line should not be empty for current process")
+
+	t.Logf("Current process (PID %d) command: %v", pid, proc.Command)
+}
+
+func Test_getRunningParentProcess(t *testing.T) {
+	pid := os.Getpid()
+	parentProc, err := GetRunningParentProcess(pid)
+
+	require.NoError(t, err, "getRunningParentProcess should not return error")
+	require.NotNil(t, parentProc, "Parent process should not be nil")
+	assert.NotEmpty(t, parentProc.Command, "Parent process command should not be empty")
+
+	t.Logf("Parent process of PID %d: %v", pid, parentProc.Command)
+}
+
+func Test_getRunningProcesses(t *testing.T) {
+	processes, err := GetRunningProcesses()
+
+	require.NoError(t, err, "getRunningProcesses should not return error")
+	assert.NotEmpty(t, processes, "Should return at least some processes")
+
+	t.Logf("Found %d running processes", len(processes))
+
+	maxLog := 5
+	if len(processes) < maxLog {
+		maxLog = len(processes)
+	}
+	for i := 0; i < maxLog; i++ {
+		t.Logf("Process %d (PID %d): %v", i, processes[i].PID, processes[i].Command)
+	}
+}
+
+func Test_getRunningParentProcessLinux(t *testing.T) {
+	pid := os.Getpid()
+	parentProc, err := getRunningParentProcessLinux(pid)
+
+	require.NoError(t, err, "getRunningParentProcessLinux should not return error")
+	require.NotNil(t, parentProc, "Parent process should not be nil")
+	assert.NotEmpty(t, parentProc.Command, "Parent process command should not be empty")
+
+	t.Logf("Parent of PID %d: %v", pid, parentProc.Command)
+}

--- a/pkg/tasks/baseline/processes_test.go
+++ b/pkg/tasks/baseline/processes_test.go
@@ -1,67 +1,11 @@
 package tasks
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func Test_getRunningProcess(t *testing.T) {
-	// Test with current process
-	pid := os.Getpid()
-	proc, err := GetRunningProcess(pid)
-
-	require.NoError(t, err, "getRunningProcess should not return error for current process")
-	require.NotNil(t, proc, "Process should not be nil")
-	assert.NotEmpty(t, proc.Command, "Command line should not be empty for current process")
-
-	t.Logf("Current process (PID %d) command: %v", pid, proc.Command)
-}
-
-func Test_getRunningParentProcess(t *testing.T) {
-	// Test with current process to get its parent
-	pid := os.Getpid()
-	parentProc, err := GetRunningParentProcess(pid)
-
-	require.NoError(t, err, "getRunningParentProcess should not return error")
-	require.NotNil(t, parentProc, "Parent process should not be nil")
-	assert.NotEmpty(t, parentProc.Command, "Parent process command should not be empty")
-
-	t.Logf("Parent process of PID %d: %v", pid, parentProc.Command)
-}
-
-func Test_getRunningProcesses(t *testing.T) {
-	// Test getting all running processes
-	processes, err := GetRunningProcesses()
-
-	require.NoError(t, err, "getRunningProcesses should not return error")
-	assert.NotEmpty(t, processes, "Should return at least some processes")
-
-	t.Logf("Found %d running processes", len(processes))
-
-	// Log first few processes
-	maxLog := 5
-	if len(processes) < maxLog {
-		maxLog = len(processes)
-	}
-	for i := 0; i < maxLog; i++ {
-		t.Logf("Process %d (PID %d): %v", i, processes[i].PID, processes[i].Command)
-	}
-}
-
-func Test_getRunningParentProcessLinux(t *testing.T) {
-	// Test getting parent process
-	pid := os.Getpid()
-	parentProc, err := getRunningParentProcessLinux(pid)
-
-	require.NoError(t, err, "getRunningParentProcessLinux should not return error")
-	require.NotNil(t, parentProc, "Parent process should not be nil")
-	assert.NotEmpty(t, parentProc.Command, "Parent process command should not be empty")
-
-	t.Logf("Parent of PID %d: %v", pid, parentProc.Command)
-}
 
 func TestStringToContainerRuntime(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
On non-Linux platforms, ProbeLandlockSelfDepth() returned (0, nil) which ProbeForLandlock() misinterpreted as 'landlocked' (depth 0 != MAX_DEPTH 16).

Fix by splitting ProbeForLandlock into a Linux-only implementation (landlock_linux.go) and a !linux stub returning (false, nil) in landlock.go, mirroring the existing pattern for ProbeLandlockSelfDepth.

Also move /proc-dependent tests (getHostMounts, getRunningProcess, getRunningParentProcess, getRunningProcesses) into *_linux_test.go files so they are skipped on macOS, and update go.sum via proxy.golang.org to resolve gitleaks v8.30.1 checksum mismatch.

Add GOPROXY=https://proxy.golang.org,direct to flake.nix devshell env to prevent the checksum mismatch from recurring.