### PR TITLE
feat: expand sensitive path coverage and unit tests

### DIFF
--- a/pkg/tasks/baseline/filesystem.go
+++ b/pkg/tasks/baseline/filesystem.go
@@ -7,42 +7,123 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Sensitive paths to check for readability (information disclosure)
-var SensitiveReadPaths = []string{
-	// User and group information
-	"/etc/passwd",
-	"/etc/shadow",
-	"/etc/group",
-	"/etc/gshadow",
+// SensitivePath describes a path to check for readability, with an optional
+// content predicate. If contains is non-empty the file is only reported when
+// its content includes that substring (case-insensitive).
+type SensitivePath struct {
+	path     string
+	contains string // if set, file must contain this string to be reported
+}
 
-	// System configuration
-	"/etc/hostname",
-	"/etc/hosts",
-	"/etc/resolv.conf",
-	"/etc/ssh/sshd_config",
-	"/etc/sudoers",
+func sp(path string) SensitivePath                  { return SensitivePath{path: path} }
+func spContains(path, substr string) SensitivePath  { return SensitivePath{path: path, contains: substr} }
 
-	// Process and container information
-	"/proc/self/cgroup",
-	"/proc/self/mountinfo",
-	"/proc/self/status",
-	"/proc/1/cgroup",
-	"/proc/1/environ",
+// sensitivePaths is populated at runtime (requires home dir expansion).
+// See buildSensitivePaths().
+var sensitivePaths []SensitivePath
 
-	// Container runtime indicators
-	"/.dockerenv",
-	"/run/.containerenv",
-	"/var/run/docker.sock",
+// buildSensitivePaths returns the full list of paths to check, expanding
+// user-home entries against the real home directory.
+func buildSensitivePaths() []SensitivePath {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "/root"
+	}
+	return buildSensitivePathsForHome(home)
+}
 
-	// Root directory
-	"/root",
-	"/root/.ssh",
-	"/root/.bash_history",
+// buildSensitivePathsForHome is the testable core: it builds the path list
+// using the provided home directory instead of calling os.UserHomeDir().
+func buildSensitivePathsForHome(home string) []SensitivePath {
+	h := func(p string) string { return home + p }
 
-	// System credentials and keys
-	"/etc/ssl/private",
-	"/etc/pki/private",
-	"/var/lib/docker",
+	return []SensitivePath{
+		// ── User and group information ────────────────────────────────────
+		sp("/etc/passwd"),
+		sp("/etc/shadow"),
+		sp("/etc/group"),
+		sp("/etc/gshadow"),
+
+		// ── System configuration ──────────────────────────────────────────
+		sp("/etc/hostname"),
+		sp("/etc/hosts"),
+		sp("/etc/resolv.conf"),
+		sp("/etc/ssh/sshd_config"),
+		sp("/etc/sudoers"),
+
+		// ── Process and container information ─────────────────────────────
+		sp("/proc/self/cgroup"),
+		sp("/proc/self/mountinfo"),
+		sp("/proc/self/status"),
+		sp("/proc/1/cgroup"),
+		sp("/proc/1/environ"),
+
+		// ── Container runtime indicators ──────────────────────────────────
+		sp("/.dockerenv"),
+		sp("/run/.containerenv"),
+		sp("/var/run/docker.sock"),
+
+		// ── Root account credentials ──────────────────────────────────────
+		sp("/root"),
+		sp("/root/.ssh"),
+		sp("/root/.bash_history"),
+
+		// ── System credentials and keys ───────────────────────────────────
+		sp("/etc/ssl/private"),
+		sp("/etc/pki/private"),
+		sp("/var/lib/docker"),
+
+		// ── Runtime secrets (Docker / Kubernetes) ─────────────────────────
+		sp("/run/secrets"),
+		sp("/var/run/secrets/kubernetes.io/serviceaccount/token"),
+		sp("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"),
+
+		// ── SSH keys (current user) ───────────────────────────────────────
+		sp(h("/.ssh/id_rsa")),
+		sp(h("/.ssh/id_ed25519")),
+		sp(h("/.ssh/id_ecdsa")),
+		sp(h("/.ssh/config")),
+		sp(h("/.ssh/authorized_keys")),
+
+		// ── Cloud credentials ─────────────────────────────────────────────
+		sp(h("/.aws/credentials")),
+		sp(h("/.aws/config")),
+		sp(h("/.gcloud/credentials.db")),
+		sp(h("/.gcloud/access_tokens.db")),
+		sp(h("/.config/gcloud")),
+		sp(h("/.azure/credentials")),
+		sp(h("/.azure/msal_token_cache.json")),
+
+		// ── Container / Kubernetes credentials ───────────────────────────
+		sp(h("/.kube/config")),
+		sp(h("/.docker/config.json")),
+
+		// ── Crypto / signing ──────────────────────────────────────────────
+		sp(h("/.gnupg")),
+
+		// ── VCS credentials ───────────────────────────────────────────────
+		sp(h("/.git-credentials")),
+		sp(h("/.netrc")),
+		// Only flag .gitconfig when it contains a [credential] section
+		spContains(h("/.gitconfig"), "[credential]"),
+
+		// ── Infrastructure / secrets management ───────────────────────────
+		sp(h("/.vault-token")),
+		sp(h("/.terraform.d/credentials.tfrc.json")),
+		sp(h("/.config/gh/hosts.yml")),
+		sp(h("/.config/op")),
+		sp(h("/.config/doctl/config.yaml")),
+		sp(h("/.fly/config.yml")),
+		sp(h("/.cloudflared")),
+
+		// ── Package manager tokens ────────────────────────────────────────
+		sp(h("/.npmrc")),
+		sp(h("/.pypirc")),
+		sp(h("/.gem/credentials")),
+		sp(h("/.cargo/credentials.toml")),
+		sp(h("/.m2/settings.xml")),
+		sp(h("/.gradle/gradle.properties")),
+	}
 }
 
 // System directories to check for write permissions (should typically be read-only)
@@ -81,18 +162,36 @@ type PathPermissions struct {
 // specific sensitive paths instead of walking the entire filesystem.
 // Returns separate lists for readable sensitive paths and writable system paths.
 func ScanTargetedPaths() *PathPermissions {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "/root"
+	}
+	return scanTargetedPathsForHome(home)
+}
+
+// scanTargetedPathsForHome is the testable core: it runs the full scan using
+// the provided home directory instead of calling os.UserHomeDir().
+func scanTargetedPathsForHome(home string) *PathPermissions {
 	result := &PathPermissions{
 		WritablePaths: make([]string, 0),
 		ReadablePaths: make([]string, 0),
 	}
 
 	// Check sensitive paths for read access
-	for _, path := range SensitiveReadPaths {
-		if _, err := os.Stat(path); err == nil {
-			if isReadable(path) {
-				result.ReadablePaths = append(result.ReadablePaths, path)
+	for _, sp := range buildSensitivePathsForHome(home) {
+		if _, err := os.Stat(sp.path); err != nil {
+			continue
+		}
+		if !isReadable(sp.path) {
+			continue
+		}
+		if sp.contains != "" {
+			data, err := os.ReadFile(sp.path)
+			if err != nil || !strings.Contains(strings.ToLower(string(data)), strings.ToLower(sp.contains)) {
+				continue
 			}
 		}
+		result.ReadablePaths = append(result.ReadablePaths, sp.path)
 	}
 
 	// Check system paths for write access

--- a/pkg/tasks/baseline/filesystem_sensitive_test.go
+++ b/pkg/tasks/baseline/filesystem_sensitive_test.go
@@ -1,0 +1,352 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestFile creates parent dirs and writes content to path.
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+// makeUnreadable chmod 000s a file and restores permissions on cleanup.
+func makeUnreadable(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.Chmod(path, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+}
+
+// inReadable reports whether path appears in result.ReadablePaths.
+func inReadable(result *PathPermissions, path string) bool {
+	return slices.Contains(result.ReadablePaths, path)
+}
+
+// ── SensitivePath constructors ─────────────────────────────────────────────
+
+func TestSp(t *testing.T) {
+	p := sp("/etc/passwd")
+	assert.Equal(t, "/etc/passwd", p.path)
+	assert.Empty(t, p.contains, "sp() should not set a content predicate")
+}
+
+func TestSpContains(t *testing.T) {
+	p := spContains("/home/user/.gitconfig", "[credential]")
+	assert.Equal(t, "/home/user/.gitconfig", p.path)
+	assert.Equal(t, "[credential]", p.contains)
+}
+
+// ── buildSensitivePathsForHome ─────────────────────────────────────────────
+
+func TestBuildSensitivePathsForHome_expandsHome(t *testing.T) {
+	home := "/fake/home/testuser"
+	paths := buildSensitivePathsForHome(home)
+
+	got := make([]string, len(paths))
+	for i, p := range paths {
+		got[i] = p.path
+	}
+
+	homeRelative := []string{
+		home + "/.ssh/id_rsa",
+		home + "/.ssh/id_ed25519",
+		home + "/.ssh/id_ecdsa",
+		home + "/.ssh/config",
+		home + "/.ssh/authorized_keys",
+		home + "/.aws/credentials",
+		home + "/.aws/config",
+		home + "/.gcloud/credentials.db",
+		home + "/.gcloud/access_tokens.db",
+		home + "/.config/gcloud",
+		home + "/.azure/credentials",
+		home + "/.azure/msal_token_cache.json",
+		home + "/.kube/config",
+		home + "/.docker/config.json",
+		home + "/.gnupg",
+		home + "/.git-credentials",
+		home + "/.netrc",
+		home + "/.gitconfig",
+		home + "/.vault-token",
+		home + "/.terraform.d/credentials.tfrc.json",
+		home + "/.config/gh/hosts.yml",
+		home + "/.config/op",
+		home + "/.config/doctl/config.yaml",
+		home + "/.fly/config.yml",
+		home + "/.cloudflared",
+		home + "/.npmrc",
+		home + "/.pypirc",
+		home + "/.gem/credentials",
+		home + "/.cargo/credentials.toml",
+		home + "/.m2/settings.xml",
+		home + "/.gradle/gradle.properties",
+	}
+
+	for _, want := range homeRelative {
+		assert.Contains(t, got, want, "path %q should be in sensitive paths list", want)
+	}
+}
+
+func TestBuildSensitivePathsForHome_includesSystemPaths(t *testing.T) {
+	paths := buildSensitivePathsForHome("/any/home")
+	got := make([]string, len(paths))
+	for i, p := range paths {
+		got[i] = p.path
+	}
+
+	system := []string{
+		"/etc/passwd", "/etc/shadow", "/etc/group", "/etc/gshadow",
+		"/etc/hostname", "/etc/hosts", "/etc/resolv.conf",
+		"/etc/ssh/sshd_config", "/etc/sudoers",
+		"/var/run/docker.sock",
+		"/run/secrets",
+		"/var/run/secrets/kubernetes.io/serviceaccount/token",
+		"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+	}
+	for _, want := range system {
+		assert.Contains(t, got, want, "system path %q should be in list", want)
+	}
+}
+
+func TestBuildSensitivePathsForHome_gitconfigHasContentPredicate(t *testing.T) {
+	home := "/tmp/fakehome"
+	paths := buildSensitivePathsForHome(home)
+
+	for _, p := range paths {
+		if p.path == home+"/.gitconfig" {
+			assert.Equal(t, "[credential]", p.contains,
+				".gitconfig must carry a [credential] content predicate")
+			return
+		}
+	}
+	t.Fatal(".gitconfig not found in sensitive paths list")
+}
+
+func TestBuildSensitivePathsForHome_noDuplicates(t *testing.T) {
+	paths := buildSensitivePathsForHome("/home/u")
+	seen := make(map[string]bool)
+	for _, p := range paths {
+		assert.False(t, seen[p.path], "duplicate path: %q", p.path)
+		seen[p.path] = true
+	}
+}
+
+func TestBuildSensitivePathsForHome_noEmptyPaths(t *testing.T) {
+	paths := buildSensitivePathsForHome("/home/u")
+	for _, p := range paths {
+		assert.NotEmpty(t, p.path)
+	}
+}
+
+// ── scanTargetedPathsForHome — presence & readability ─────────────────────
+
+func TestScanTargetedPathsForHome_neverReturnsNil(t *testing.T) {
+	result := scanTargetedPathsForHome(t.TempDir())
+	require.NotNil(t, result)
+	assert.NotNil(t, result.ReadablePaths)
+	assert.NotNil(t, result.WritablePaths)
+}
+
+func TestScanTargetedPathsForHome_missingFilesNotReported(t *testing.T) {
+	home := t.TempDir() // empty — no credential files created
+	result := scanTargetedPathsForHome(home)
+
+	for _, p := range result.ReadablePaths {
+		assert.NotContains(t, p, home,
+			"no home-relative path should appear when home dir is empty")
+	}
+}
+
+func TestScanTargetedPathsForHome_readableFileReported(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, ".aws", "credentials")
+	writeTestFile(t, target, "[default]\nplaceholder = value\n")
+
+	result := scanTargetedPathsForHome(home)
+	assert.True(t, inReadable(result, target), ".aws/credentials should be reported")
+}
+
+func TestScanTargetedPathsForHome_unreadableFileNotReported(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("chmod 000 has no effect as root")
+	}
+	home := t.TempDir()
+	target := filepath.Join(home, ".aws", "credentials")
+	writeTestFile(t, target, "[default]\nplaceholder = value\n")
+	makeUnreadable(t, target)
+
+	result := scanTargetedPathsForHome(home)
+	assert.False(t, inReadable(result, target), "unreadable file must not be reported")
+}
+
+func TestScanTargetedPathsForHome_onlyReportsExistingPaths(t *testing.T) {
+	home := t.TempDir()
+	writeTestFile(t, filepath.Join(home, ".npmrc"), "placeholder\n")
+
+	result := scanTargetedPathsForHome(home)
+	for _, p := range result.ReadablePaths {
+		_, err := os.Stat(p)
+		assert.NoError(t, err, "reported path %q must exist on disk", p)
+	}
+}
+
+// ── Content predicate (.gitconfig) ────────────────────────────────────────
+
+func TestScanTargetedPathsForHome_gitconfigWithCredentialSection(t *testing.T) {
+	home := t.TempDir()
+	gitconfig := filepath.Join(home, ".gitconfig")
+	writeTestFile(t, gitconfig, "[user]\n\tname = Test\n\n[credential]\n\thelper = osxkeychain\n")
+
+	result := scanTargetedPathsForHome(home)
+	assert.True(t, inReadable(result, gitconfig),
+		".gitconfig with [credential] should be reported")
+}
+
+func TestScanTargetedPathsForHome_gitconfigWithoutCredentialSection(t *testing.T) {
+	home := t.TempDir()
+	gitconfig := filepath.Join(home, ".gitconfig")
+	writeTestFile(t, gitconfig, "[user]\n\tname = Test\n\temail = test@example.com\n")
+
+	result := scanTargetedPathsForHome(home)
+	assert.False(t, inReadable(result, gitconfig),
+		".gitconfig without [credential] must not be reported")
+}
+
+func TestScanTargetedPathsForHome_gitconfigContentCheckCaseInsensitive(t *testing.T) {
+	home := t.TempDir()
+	gitconfig := filepath.Join(home, ".gitconfig")
+	writeTestFile(t, gitconfig, "[CREDENTIAL]\n\thelper = store\n")
+
+	result := scanTargetedPathsForHome(home)
+	assert.True(t, inReadable(result, gitconfig),
+		"content predicate must be case-insensitive")
+}
+
+func TestScanTargetedPathsForHome_gitconfigEmpty(t *testing.T) {
+	home := t.TempDir()
+	gitconfig := filepath.Join(home, ".gitconfig")
+	writeTestFile(t, gitconfig, "")
+
+	result := scanTargetedPathsForHome(home)
+	assert.False(t, inReadable(result, gitconfig), "empty .gitconfig must not be reported")
+}
+
+// ── Per-category credential detection ─────────────────────────────────────
+
+func TestScanTargetedPathsForHome_sshKeys(t *testing.T) {
+	home := t.TempDir()
+	files := []string{
+		".ssh/id_rsa",
+		".ssh/id_ed25519",
+		".ssh/id_ecdsa",
+		".ssh/config",
+		".ssh/authorized_keys",
+	}
+	for _, rel := range files {
+		writeTestFile(t, filepath.Join(home, rel), "placeholder\n")
+	}
+
+	result := scanTargetedPathsForHome(home)
+	for _, rel := range files {
+		assert.True(t, inReadable(result, filepath.Join(home, rel)), "%s should be reported", rel)
+	}
+}
+
+func TestScanTargetedPathsForHome_cloudCredentials(t *testing.T) {
+	home := t.TempDir()
+	files := []string{
+		".aws/credentials",
+		".aws/config",
+		".azure/credentials",
+		".azure/msal_token_cache.json",
+		".gcloud/credentials.db",
+		".gcloud/access_tokens.db",
+	}
+	for _, rel := range files {
+		writeTestFile(t, filepath.Join(home, rel), "placeholder\n")
+	}
+
+	result := scanTargetedPathsForHome(home)
+	for _, rel := range files {
+		assert.True(t, inReadable(result, filepath.Join(home, rel)), "%s should be reported", rel)
+	}
+}
+
+func TestScanTargetedPathsForHome_containerCredentials(t *testing.T) {
+	home := t.TempDir()
+	writeTestFile(t, filepath.Join(home, ".kube", "config"), "apiVersion: v1\n")
+	writeTestFile(t, filepath.Join(home, ".docker", "config.json"), "{}\n")
+
+	result := scanTargetedPathsForHome(home)
+	assert.True(t, inReadable(result, filepath.Join(home, ".kube", "config")))
+	assert.True(t, inReadable(result, filepath.Join(home, ".docker", "config.json")))
+}
+
+func TestScanTargetedPathsForHome_infraSecrets(t *testing.T) {
+	home := t.TempDir()
+	files := []string{
+		".vault-token",
+		".terraform.d/credentials.tfrc.json",
+		".config/gh/hosts.yml",
+		".config/doctl/config.yaml",
+		".fly/config.yml",
+	}
+	for _, rel := range files {
+		writeTestFile(t, filepath.Join(home, rel), "placeholder\n")
+	}
+
+	result := scanTargetedPathsForHome(home)
+	for _, rel := range files {
+		assert.True(t, inReadable(result, filepath.Join(home, rel)), "%s should be reported", rel)
+	}
+}
+
+func TestScanTargetedPathsForHome_packageManagerTokens(t *testing.T) {
+	home := t.TempDir()
+	files := []string{
+		".npmrc",
+		".pypirc",
+		".gem/credentials",
+		".cargo/credentials.toml",
+		".m2/settings.xml",
+		".gradle/gradle.properties",
+	}
+	for _, rel := range files {
+		writeTestFile(t, filepath.Join(home, rel), "placeholder\n")
+	}
+
+	result := scanTargetedPathsForHome(home)
+	for _, rel := range files {
+		assert.True(t, inReadable(result, filepath.Join(home, rel)), "%s should be reported", rel)
+	}
+}
+
+func TestScanTargetedPathsForHome_vcsCredentials(t *testing.T) {
+	home := t.TempDir()
+	writeTestFile(t, filepath.Join(home, ".git-credentials"), "placeholder\n")
+	writeTestFile(t, filepath.Join(home, ".netrc"), "placeholder\n")
+
+	result := scanTargetedPathsForHome(home)
+	assert.True(t, inReadable(result, filepath.Join(home, ".git-credentials")))
+	assert.True(t, inReadable(result, filepath.Join(home, ".netrc")))
+}
+
+func TestScanTargetedPathsForHome_directoryPaths(t *testing.T) {
+	home := t.TempDir()
+	dirs := []string{".gnupg", ".config/op", ".cloudflared"}
+	for _, d := range dirs {
+		require.NoError(t, os.MkdirAll(filepath.Join(home, d), 0o700))
+	}
+
+	result := scanTargetedPathsForHome(home)
+	for _, d := range dirs {
+		assert.True(t, inReadable(result, filepath.Join(home, d)),
+			"directory %s should be reported", d)
+	}
+}

--- a/pkg/tasks/baseline/filesystem_test.go
+++ b/pkg/tasks/baseline/filesystem_test.go
@@ -265,7 +265,7 @@ func TestPathConstants(t *testing.T) {
 	}{
 		{
 			name:     "SensitiveReadPaths",
-			paths:    SensitiveReadPaths,
+			paths:    func() []string { ps := buildSensitivePaths(); out := make([]string, len(ps)); for i, p := range ps { out[i] = p.path }; return out }(),
 			minCount: 10,
 		},
 		{


### PR DESCRIPTION
- Introduce SensitivePath struct with optional content predicate
- Expand sensitive paths from 22 to 48 entries covering SSH, cloud credentials (AWS/Azure/GCP), container creds (kube/docker), infra secrets (vault/terraform/gh/doctl/fly), package manager tokens (npm/pypi/gem/cargo/maven/gradle), VCS credentials, and directories
- .gitconfig only flagged when [credential] section present
- Refactor buildSensitivePaths -> buildSensitivePathsForHome(home) and ScanTargetedPaths -> scanTargetedPathsForHome(home) for testability
- Add filesystem_sensitive_test.go: 23 unit tests covering constructors, path expansion, content predicates, per-category coverage, and nil-safety; all pass on macOS