### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Our Security Address
+
+Contact: `security@control-plane.io`
+Encryption: `https://keybase.io/sublimino/pgp_keys.asc`
+Disclosure: `Full`


### PR DESCRIPTION
## Summary
- Adds a `SECURITY.md` matching the convention used by `netassert` and `simulator` in the controlplaneio org (security.txt-format Contact/Encryption/Disclosure rendered in Markdown).