### PR TITLE
feat(ci): cross-OS gemini sandbox scan matrix + windows port

### DIFF
--- a/.github/workflows/scan-gemini-matrix.yaml
+++ b/.github/workflows/scan-gemini-matrix.yaml
@@ -1,0 +1,131 @@
+name: scan-gemini-matrix
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["matrix/**"]
+  schedule:
+    - cron: "0 8 * * 1" # weekly
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scan-gemini-matrix-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GEMINI_MODEL: gemini-2.5-flash-lite
+  RUN_VIA_GEMINI: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+
+jobs:
+  build:
+    name: build (${{ matrix.goos }}/${{ matrix.goarch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest,  goos: linux,   goarch: amd64, ext: "" }
+          - { runner: macos-latest,   goos: darwin,  goarch: arm64, ext: "" }
+          - { runner: windows-latest, goos: windows, goarch: amd64, ext: ".exe" }
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with: { go-version-file: go.mod }
+      - shell: bash
+        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o sandbox-probe${{ matrix.ext }} .
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sandbox-probe-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: sandbox-probe${{ matrix.ext }}
+
+  scan:
+    name: ${{ matrix.label }}
+    needs: build
+    environment: gemini
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { label: linux-none,         runner: ubuntu-latest,  arch: linux-amd64,   ext: "",     backend: "" }
+          - { label: linux-docker,       runner: ubuntu-latest,  arch: linux-amd64,   ext: "",     backend: docker }
+          - { label: linux-podman,       runner: ubuntu-latest,  arch: linux-amd64,   ext: "",     backend: podman }
+          - { label: macos-none,         runner: macos-latest,   arch: darwin-arm64,  ext: "",     backend: "" }
+          - { label: macos-sandbox-exec, runner: macos-latest,   arch: darwin-arm64,  ext: "",     backend: sandbox-exec }
+          # windows-docker omitted: gemini sandbox image is Linux-only, no native Windows sandbox in gemini-cli.
+          - { label: windows-none,       runner: windows-latest, arch: windows-amd64, ext: ".exe", backend: "" }
+    runs-on: ${{ matrix.runner }}
+    env:
+      RUN_GEMINI: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && secrets.GEMINI_API_KEY != '' }}
+      PROBE: ./sandbox-probe${{ matrix.ext }}
+      DIRECT_REPORT: reports/${{ matrix.label }}-direct.json
+      GEMINI_REPORT: reports/${{ matrix.label }}-via-gemini.json
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v6
+        with:
+          name: sandbox-probe-${{ matrix.arch }}
+
+      - if: runner.os != 'Windows'
+        run: chmod +x $PROBE
+
+      - if: matrix.backend == 'podman' && runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y podman
+
+      - if: matrix.backend == 'docker' && runner.os == 'Linux'
+        run: docker info
+
+      - if: env.RUN_GEMINI == 'true'
+        uses: actions/setup-node@v6
+        with: { node-version: "22" }
+
+      - if: env.RUN_GEMINI == 'true'
+        run: npm install -g @google/gemini-cli && gemini --version
+        shell: bash
+
+      - name: probe (direct)
+        id: direct
+        shell: bash
+        run: |
+          mkdir -p reports
+          $PROBE scan --tasksets baseline \
+            --tags "runner=${{ matrix.runner }},backend=${{ matrix.backend || 'none' }},mode=direct" \
+            --output_path "$DIRECT_REPORT"
+
+      - name: probe (via gemini)
+        id: via_gemini
+        if: env.RUN_GEMINI == 'true'
+        shell: bash
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_SANDBOX: ${{ matrix.backend }}
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
+          SANDBOX_FLAGS: '--entrypoint ""' # gemini-cli#26964 workaround
+          LABEL: ${{ matrix.label }}
+          RUNNER: ${{ matrix.runner }}
+          BACKEND: ${{ matrix.backend || 'none' }}
+          OUT: ${{ env.GEMINI_REPORT }}
+          MODEL: ${{ env.GEMINI_MODEL }}
+        run: ./scripts/run-probe-via-gemini.sh
+
+      - name: summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## ${{ matrix.label }}"
+            echo "| | |"
+            echo "|---|---|"
+            echo "| backend | \`${{ matrix.backend || 'none' }}\` |"
+            echo "| direct | \`${{ steps.direct.outcome }}\` |"
+            echo "| via gemini | \`${{ steps.via_gemini.outcome || 'skipped' }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: report-${{ matrix.label }}
+          path: reports/
+          if-no-files-found: ignore

--- a/pkg/tasks/baseline/filesystem.go
+++ b/pkg/tasks/baseline/filesystem.go
@@ -3,8 +3,6 @@ package tasks
 import (
 	"os"
 	"strings"
-
-	"golang.org/x/sys/unix"
 )
 
 // SensitivePath describes a path to check for readability, with an optional
@@ -265,38 +263,6 @@ func scanTargetedPathsForHome(home string) *PathPermissions {
 
 // 	return result, nil
 // }
-
-// isReadable checks if the current process can read the given path.
-// First we check POSIX access, if no access is reported, we return false
-// If access through POSIX is reported, we verify it trying opening the file
-func isReadable(path string) bool {
-	err := unix.Access(path, unix.R_OK)
-	if err != nil {
-		return false
-	}
-	f, err := os.OpenFile(path, os.O_RDONLY, 0)
-	if err != nil {
-		return false
-	}
-	f.Close()
-	return true
-}
-
-// isWritable checks if the current process can write to the given path.
-// First we check POSIX access, if no access is reported, we return false
-// If access through POSIX is reported, we verify it trying opening the file
-func isWritable(path string) bool {
-	err := unix.Access(path, unix.W_OK)
-	if err != nil {
-		return false
-	}
-	f, err := os.OpenFile(path, os.O_WRONLY, 0)
-	if err != nil {
-		return false
-	}
-	f.Close()
-	return true
-}
 
 // isPseudoFilesystem returns true if the path is in a pseudo-filesystem
 // that should be skipped during security enumeration

--- a/pkg/tasks/baseline/filesystem_unix.go
+++ b/pkg/tasks/baseline/filesystem_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+// +build !windows
+
+package tasks
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func isReadable(path string) bool {
+	if err := unix.Access(path, unix.R_OK); err != nil {
+		return false
+	}
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return false
+	}
+	f.Close()
+	return true
+}
+
+func isWritable(path string) bool {
+	if err := unix.Access(path, unix.W_OK); err != nil {
+		return false
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return false
+	}
+	f.Close()
+	return true
+}

--- a/pkg/tasks/baseline/filesystem_windows.go
+++ b/pkg/tasks/baseline/filesystem_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+// +build windows
+
+package tasks
+
+import "os"
+
+// On Windows we don't have POSIX access(2). The cheapest reliable signal
+// is to open the file with the requested access and report success/failure;
+// the OS evaluates the ACL during the open call.
+func isReadable(path string) bool {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return false
+	}
+	f.Close()
+	return true
+}
+
+func isWritable(path string) bool {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return false
+	}
+	f.Close()
+	return true
+}

--- a/scripts/run-probe-via-gemini.sh
+++ b/scripts/run-probe-via-gemini.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run sandbox-probe via gemini-cli with the matrix's chosen sandbox backend.
+# Required env: PROBE, LABEL, RUNNER, BACKEND, OUT, MODEL
+# Optional: GEMINI_SANDBOX (empty = no --sandbox), GEMINI_API_KEY.
+#
+# Workaround for google-gemini/gemini-cli#26964 (broken in v0.42.0): the
+# sandbox image has a default ENTRYPOINT ["gemini"], so we force
+# --entrypoint "" via SANDBOX_FLAGS. Drop once a fixed release lands.
+set -eo pipefail
+
+: "${PROBE:?}" "${LABEL:?}" "${RUNNER:?}" "${BACKEND:?}" "${OUT:?}" "${MODEL:?}"
+
+mkdir -p "$(dirname "$OUT")"
+
+VERSION=$(gemini --version)
+TAGS="runner=${RUNNER},backend=${BACKEND},gemini=${VERSION},mode=via-gemini"
+PROMPT="Run this exact shell command and then exit: ${PROBE} scan --tasksets baseline --tags ${TAGS} --output_path ${OUT}"
+
+SANDBOX_FLAG=()
+[ -n "${GEMINI_SANDBOX:-}" ] && SANDBOX_FLAG=(--sandbox)
+
+for attempt in 1 2 3; do
+  echo "::group::gemini attempt ${attempt}/3"
+  if gemini --yolo --skip-trust --model "$MODEL" --prompt "$PROMPT" "${SANDBOX_FLAG[@]}" 2>&1 | tee gemini.log; then
+    echo "::endgroup::"
+    break
+  fi
+  echo "::endgroup::"
+  if grep -qi 'quota\|rate.*limit\|429' gemini.log; then
+    echo "::error::gemini quota/rate-limit — not retrying"
+    exit 1
+  fi
+  [ "$attempt" -lt 3 ] && sleep $((attempt * 5))
+done
+
+[ -f "$OUT" ] || { echo "::error::gemini did not produce $OUT"; exit 1; }


### PR DESCRIPTION
## Summary

Two things bundled because they unblock each other:

1. **Windows build fix.** `pkg/tasks/baseline/filesystem.go` uses `unix.Access`/`R_OK`/`W_OK` which don't exist on `GOOS=windows`. Split into `filesystem_unix.go` / `filesystem_windows.go` with the same semantics (POSIX `access(2)` precheck on Unix; `OpenFile` only on Windows since there's no ACL-cheap precheck). All three OS builds compile clean now.
2. **`scan-gemini-matrix.yaml`** — a workflow that fans the baseline scan out across the sandbox surfaces the gemini CLI can actually use today:

   |             | none | docker | podman | sandbox-exec |
   |---          |---   |---     |---     |---           |
   | **linux**   | ✅   | ✅     | ✅     | —            |
   | **macos**   | ✅   | —      | —      | ✅           |
   | **windows** | ✅   | —*     | —      | —            |

   \* `windows-docker` deliberately omitted — gemini's `--sandbox` image is a Linux container and Docker Desktop on `windows-latest` can't pull it. That's a finding, not a cell worth running.

This is the start of expanding the matrix. The same pattern (build × OS, then scan × {OS, sandbox backend}) is intended to cover the other sandbox things the probe already supports — Claude's sandbox, plain Docker/Podman/bwrap as host-side baselines, etc. — so we end up with one workflow that exercises every supported `(tool, OS, backend)` combination instead of one bespoke script per tool.

## Design notes

- Build matrix → upload-artifact → scan matrix → download. Lets us reuse one cross-compiled binary per OS across all backend variants.
- Each scan cell runs the probe **directly** *and* (when permitted) **via `gemini --sandbox <backend>`**, uploading both reports. Direct gives a baseline; via-gemini exercises gemini's own sandboxing.
- Token spend gated: pushes only run the direct probes (free). The via-gemini path runs only on `workflow_dispatch` and the weekly cron.
- `concurrency: cancel-in-progress` per `(event, ref)` so superseded runs don't burn tokens.
- `GEMINI_API_KEY` is read from a `gemini` deployment environment with a branch policy restricted to `main` + `matrix/**`. Maintainers wanting to enable the via-gemini phase would create that environment + secret on their fork/repo; absent it, the step skips cleanly.
- Model pinned to `gemini-2.5-flash-lite` (cheapest tier). Retry on 5xx, fail fast on 429 so quota issues surface.

## Upstream gemini-cli bugs found

This matrix surfaced two real upstream issues that the existing `tests/baseline_gemini.sh` would also have hit if anyone ran it non-interactively in CI:

1. **`Unknown argument: c`** on `gemini --sandbox` with `GEMINI_SANDBOX=docker|podman` in v0.42.0 — the sandbox image's default `ENTRYPOINT ["gemini"]` eats the inner `bash -c "<cmd>"`. Tracked at [google-gemini/gemini-cli#26964](https://github.com/google-gemini/gemini-cli/issues/26964), fix merged in [PR #27059](https://github.com/google-gemini/gemini-cli/pull/27059) but not yet released. Worked around here via `SANDBOX_FLAGS='--entrypoint ""'`.
2. **Workspace-trust env var doesn't cross the sandbox re-exec.** `GEMINI_CLI_TRUST_WORKSPACE=true` on the outer process is dropped when gemini re-execs inside the container, so the inner gemini refuses to run. Worked around by passing `--skip-trust` on argv.

Both workarounds are commented inline and tagged for removal when a fixed gemini-cli release lands.