### PR TITLE
feat(config): declarative custom-paths boundary checking via --config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       semver: ${{ steps.version.outputs.semantic_version }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -42,22 +42,23 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
-      - name: Tag release
+      - name: Create local release tag
         run: |
           git tag "v${{ needs.version.outputs.semver }}"
-          git push origin "v${{ needs.version.outputs.semver }}"
+          # GoReleaser creates the remote release and tag only after artifacts
+          # build successfully. Do not push a tag before that transaction.
 
       - name: Launch goreleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           args: release
         env:

--- a/.github/workflows/scan-gemini.yaml
+++ b/.github/workflows/scan-gemini.yaml
@@ -37,9 +37,11 @@ jobs:
           HASH_CLEAN=$(echo "$HASH" | cut -d: -f 2)
           TAG=$(echo "$hash_tag" | cut -d',' -f2)
 
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
-          echo "hash_clean=$HASH_CLEAN" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag=$TAG"
+            echo "hash=$HASH"
+            echo "hash_clean=$HASH_CLEAN"
+          } >> "$GITHUB_OUTPUT"
           echo -e "Outputs\nTAG: $TAG\nHASH: $HASH\HASH_CLEAN: $HASH_CLEAN"
 
       #  not storing reports in GH right now

--- a/.github/workflows/scan-matrix.yaml
+++ b/.github/workflows/scan-matrix.yaml
@@ -119,7 +119,7 @@ jobs:
         with:
           name: sandbox-probe-${{ matrix.arch }}
       - if: runner.os != 'Windows'
-        run: chmod +x $PROBE
+        run: chmod +x "$PROBE"
       - run: mkdir -p reports
         shell: bash
 

--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,10 @@ results/
 .direnv/
 
 /reports
-
 # trae-agent writes run trajectories here when driving the probe (scripts/run-probe-via-trae-stub.sh)
 trajectories/
+
+MEMORY/
+
+# Personal test directories (machine-specific configs — keep in private repos)
+tests/cpai-*/

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,18 @@ e2etests: ## Run end-to-end tests
 	@echo "All e2e tests completed successfully!"
 
 # Installation targets
+PREFIX ?= $(HOME)/.local/bin
+
+.PHONY: install
+install: build ## Install sandbox-probe to PREFIX (default: ~/.local/bin)
+	@mkdir -p $(PREFIX)
+	@install -m 755 bin/$(NAME) $(PREFIX)/$(NAME)
+	@echo "Installed $(NAME) to $(PREFIX)/$(NAME)"
+
+.PHONY: docker-test
+docker-test: build ## Build Docker example and run alice/bob boundary demo (requires Docker)
+	@bash tests/example/run.sh
+
 .PHONY: install-buf
 install-buf: ## Install buf tool
 	BIN="/usr/local/bin" && \

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ fmt: ## Format Go code
 tests: ## Run all Go tests
 	go test -v ./...
 
+.PHONY: test
+test: tests ## Run all Go tests
+
 # Testing targets
 .PHONY: e2etests
 e2etests: ## Run end-to-end tests
@@ -58,6 +61,9 @@ e2etests: ## Run end-to-end tests
 	@echo "Running e2e tests..."
 	@for test in tests/*.sh; do \
 		if [ -f "$$test" ]; then \
+			case "$$test" in \
+				*_interactive.sh) echo "Skipping interactive test $$test (run manually)"; continue ;; \
+			esac; \
 			echo "Running $$test..."; \
 			bash "$$test" || exit 1; \
 		fi \
@@ -74,7 +80,9 @@ install: build ## Install sandbox-probe to PREFIX (default: ~/.local/bin)
 	@echo "Installed $(NAME) to $(PREFIX)/$(NAME)"
 
 .PHONY: docker-test
-docker-test: build ## Build Docker example and run alice/bob boundary demo (requires Docker)
+docker-test: ## Build a Linux binary and run the alice/bob boundary demo (requires Docker)
+	@mkdir -p bin
+	@CGO_ENABLED=0 GOOS=linux GOARCH=$$(go env GOARCH) go build $(GO_LDFLAGS_STATIC) -o bin/sandbox-probe .
 	@bash tests/example/run.sh
 
 .PHONY: install-buf

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Quick start](#quick-start)
 - [Testing an agent's sandbox](#testing-an-agents-sandbox)
 - [CLI reference](#cli-reference)
+- [Custom path expectations](#custom-path-expectations)
 - [Report format](#report-format)
 - [Supported code assistants](#supported-code-assistants)
 - [Installation](#installation)
@@ -184,6 +185,7 @@ Run the configured tasks and write a JSON report.
 | `--output_path` | Path to write the JSON report | `report.json` |
 | `--tags` | Metadata tags to append to the report (comma-separated) | _none_ |
 | `--fast` | Skip "likely safe" paths for quicker iteration | `false` |
+| `--config` | YAML file declaring custom filesystem boundary expectations | _none_ |
 
 Examples:
 
@@ -199,7 +201,14 @@ Examples:
 
 # Custom output path
 ./bin/sandbox-probe scan --output_path results.json
+
+# Check environment-specific filesystem boundaries
+./bin/sandbox-probe scan \
+  --config tests/example/alice-sandbox.yaml \
+  --output_path results.json
 ```
+
+`--config` is a global flag, so it may appear before or after `scan`.
 
 ### `tasks list`
 
@@ -225,6 +234,94 @@ Example output:
 version dev
 git commit 44f7a7bcd2d3ae4215de43dd4d893c3b24587f40
 build date 2026-05-16T10:39:11Z
+```
+
+## Custom path expectations
+
+A custom-path policy turns environment-specific filesystem boundaries into
+executable expectations. This complements the built-in baseline: use it to
+assert that an agent cannot reach a host user's credentials while retaining
+access to its toolchain and workspace.
+
+Run a policy with `--config`:
+
+```bash
+./bin/sandbox-probe scan \
+  --config tests/example/alice-sandbox.yaml \
+  --output_path report.json
+```
+
+The example at
+[`tests/example/alice-sandbox.yaml`](./tests/example/alice-sandbox.yaml) models
+an agent user (`alice`) separated from a human operator (`bob`). The `identity`
+block is informational only; paths are always taken from the explicit
+`custom_paths` entries.
+
+### Categories and default checks
+
+| Category | Meaning | Default checks |
+| --- | --- | --- |
+| `must_block` | The path must be inaccessible. | `readdir`, `open`, and `write` must be denied. `stat` visibility is recorded but does not violate the expectation. |
+| `must_read` | The path must be accessible for directory reading. | `readdir` must succeed. |
+| `must_readwrite` | The path must be usable as a read-write location. | `readdir` and `write` must succeed. |
+| `audit` | Record observed access without asserting a policy. | `stat`, `readdir`, `open`, and `write` are recorded. |
+
+`check_ops` replaces the defaults for an entry rather than adding to them.
+Supported operations are category-specific:
+
+- `must_block`: `readdir`, `open`, `write`
+- `must_read`: `stat`, `readdir`, `open`
+- `must_readwrite` and `audit`: `stat`, `readdir`, `open`, `write`
+
+For `must_block`, `check_files` adds `open` checks for named files beneath the
+directory. Values must be simple file names: absolute paths and traversal such
+as `../secret` are rejected. `stat_may_fail: true` permits a missing
+`must_read` or `must_readwrite` path without producing a violation; other
+access failures are still violations.
+
+### Severity and exit status
+
+Expectation entries require a `severity` of `critical`, `error`, or `warn`.
+Both `critical` and `error` violations make the command exit non-zero. The
+probe still completes its selected tasks and writes the JSON report before
+returning that failure, so CI retains the evidence. A `warn` violation is
+included as a finding without failing the command. `audit` entries have no
+pass/fail verdict and do not require severity.
+
+### Validation and portable paths
+
+The parser rejects unknown fields, multiple YAML documents, empty policies,
+unsupported operations, and entries without an absolute path. A path may use:
+
+- POSIX absolute form: `/home/alice/workspace`
+- Windows drive form: `C:\Users\Alice\workspace` or `D:/Users/Alice/workspace`
+- Windows UNC form: `\\server\share\path`
+
+This allows a policy targeting one platform to be validated in CI on another.
+Drive-relative paths such as `C:temp` and ordinary relative paths are rejected.
+
+Minimal example:
+
+```yaml
+custom_paths:
+  must_block:
+    - path: /home/bob/.ssh
+      label: host_ssh_keys
+      severity: critical
+      reason: Host credentials must not be visible to the agent
+      check_files: [id_rsa, id_ed25519]
+
+  must_readwrite:
+    - path: /home/alice/workspace
+      label: agent_workspace
+      severity: error
+      reason: The agent needs a usable workspace
+
+  audit:
+    - path: /proc/self
+      label: own_process
+      check_ops: [stat, open]
+      note: Record process information exposure without failing
 ```
 
 ## Report format

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ block is informational only; paths are always taken from the explicit
 
 | Category | Meaning | Default checks |
 | --- | --- | --- |
-| `must_block` | The path must be inaccessible. | `readdir`, `open`, and `write` must be denied. `stat` visibility is recorded but does not violate the expectation. |
+| `must_block` | The path must be inaccessible. | `readdir`, `open`, and `write` must be denied. `stat` visibility is permitted and does not violate the expectation. |
 | `must_read` | The path must be accessible for directory reading. | `readdir` must succeed. |
 | `must_readwrite` | The path must be usable as a read-write location. | `readdir` and `write` must succeed. |
 | `audit` | Record observed access without asserting a policy. | `stat`, `readdir`, `open`, and `write` are recorded. |
@@ -431,13 +431,29 @@ curl -LO "https://github.com/controlplaneio/sandbox-probe/releases/latest/downlo
 
 grep " ${ARCHIVE}$" sandbox-probe_checksums.txt | shasum -a 256 -c -
 tar -xzf "${ARCHIVE}"
+mkdir -p ~/.local/bin
 install -m 0755 sandbox-probe ~/.local/bin/sandbox-probe
+export PATH="$HOME/.local/bin:$PATH"
 sandbox-probe version
 ```
 
-Windows releases use `.zip` archives. Verify the downloaded archive against
-`sandbox-probe_checksums.txt` before extracting it and placing
-`sandbox-probe.exe` on `PATH`.
+Add `~/.local/bin` to your shell profile if it is not already on `PATH`.
+
+Windows releases use `.zip` archives. Verify one from PowerShell before
+extracting it and placing `sandbox-probe.exe` on `PATH`:
+
+```powershell
+$Archive = "sandbox-probe_windows_amd64.zip"
+$Line = Get-Content .\sandbox-probe_checksums.txt |
+  Where-Object { $_.EndsWith("  $Archive") }
+if (-not $Line) { throw "No checksum found for $Archive" }
+
+$Expected = ($Line -split '\s+')[0].ToLower()
+$Actual = (Get-FileHash ".\$Archive" -Algorithm SHA256).Hash.ToLower()
+if ($Actual -ne $Expected) { throw "Checksum mismatch for $Archive" }
+
+Expand-Archive ".\$Archive" -DestinationPath .\sandbox-probe
+```
 
 ### Build from source
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,34 @@ For end-to-end testing (depending on which sandboxes you want to exercise):
 - `gemini-cli` — Gemini CLI for Gemini testing
 - [`nono`](https://github.com/always-further/nono) — a Landlock/Seatbelt wrapper for AI agents and other programs
 
+### Install a released binary
+
+GitHub releases provide archives for:
+
+- macOS: `amd64`, `arm64`
+- Linux: `amd64`, `arm64`, `armv6`, `armv7`
+- Windows: `amd64`, `arm64`
+
+Download the archive for your platform from the
+[`sandbox-probe` releases page](https://github.com/controlplaneio/sandbox-probe/releases).
+For example, on an Apple Silicon Mac:
+
+```bash
+ARCHIVE="sandbox-probe_darwin_arm64.tar.gz"
+
+curl -LO "https://github.com/controlplaneio/sandbox-probe/releases/latest/download/${ARCHIVE}"
+curl -LO "https://github.com/controlplaneio/sandbox-probe/releases/latest/download/sandbox-probe_checksums.txt"
+
+grep " ${ARCHIVE}$" sandbox-probe_checksums.txt | shasum -a 256 -c -
+tar -xzf "${ARCHIVE}"
+install -m 0755 sandbox-probe ~/.local/bin/sandbox-probe
+sandbox-probe version
+```
+
+Windows releases use `.zip` archives. Verify the downloaded archive against
+`sandbox-probe_checksums.txt` before extracting it and placing
+`sandbox-probe.exe` on `PATH`.
+
 ### Build from source
 
 ```bash

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -12,6 +12,7 @@ var cfgFile string
 
 func init() {
 	rootCmd.Flags().String("log_level", "info", "log level")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "path to custom-paths config file (YAML)")
 }
 
 var (
@@ -42,13 +43,12 @@ func Execute() {
 }
 
 func initConfig() error {
-	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
-	} else {
-		viper.SetConfigName("config")
-		viper.SetConfigType("yaml")
-		viper.AddConfigPath(".")
-	}
+	// cfgFile is our custom-paths config (domain YAML) — do not feed it to
+	// viper, which expects its own config format. Viper looks for a
+	// conventional "config.yaml" in the working directory instead.
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+	viper.AddConfigPath(".")
 
 	viper.AutomaticEnv()
 
@@ -56,6 +56,6 @@ func initConfig() error {
 		return nil
 	}
 
-	log.Info().Msgf("Using config: %s", viper.ConfigFileUsed())
+	log.Info().Msgf("Using viper config: %s", viper.ConfigFileUsed())
 	return nil
 }

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/controlplaneio/sandbox-probe/pkg/config"
 	"github.com/controlplaneio/sandbox-probe/pkg/probes"
 	"github.com/controlplaneio/sandbox-probe/pkg/tasks"
 	"github.com/rs/zerolog/log"
@@ -77,6 +78,18 @@ func scan() error {
 	loadedTasks, err := loadtasks()
 	if err != nil {
 		return err
+	}
+
+	// Load custom-paths config and append the custom task if a config was given.
+	if cfgFile != "" {
+		cfg, err := config.LoadConfig(cfgFile)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+		if cfg != nil {
+			log.Info().Str("config", cfgFile).Msg("Custom-paths config loaded")
+			loadedTasks = append(loadedTasks, tasks.NewCustomPathsTask(cfg))
+		}
 	}
 
 	p, err := probes.NewProbe(

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -101,11 +101,16 @@ func scan() error {
 		return err
 	}
 
-	if err := p.Run(); err != nil {
-		return err
+	runErr := p.Run()
+	if runErr != nil {
+		log.Warn().Err(runErr).Msg("Probe completed with failed checks")
 	}
 
-	log.Info().Msg("Probe execution completed successfully")
+	if runErr == nil {
+		log.Info().Msg("Probe execution completed successfully")
+	} else {
+		log.Warn().Msg("Probe execution completed with failed checks")
+	}
 	log.Info().Msg("Creating the report")
 
 	// Create the report
@@ -148,5 +153,5 @@ func scan() error {
 	log.Info().Str("file", viper.GetString("output_path")).Msg("Report written successfully")
 	log.Info().Msg("Sandbox probe completed")
 
-	return nil
+	return runErr
 }

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -38,7 +38,7 @@ func list() error {
 	}
 
 	if len(tsks) != len(tasksNames) {
-		fmt.Errorf("Mismatch between task names and tasks")
+		return fmt.Errorf("mismatch between task names and tasks")
 	}
 
 	// Find max task name length for alignment

--- a/go.mod
+++ b/go.mod
@@ -81,5 +81,5 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,158 @@
+// Package config loads and validates the sandbox-probe custom-paths config file.
+//
+// Schema (YAML):
+//
+//	identity:
+//	  sandbox_user: alice           # AI agent unix user
+//	  sandbox_uid: 1001
+//	  host_user: bob                # human operator unix user
+//	  host_uid: 1000
+//	  shared_gid: 1002              # optional: GID shared between sandbox and host
+//	  nono_profile: my-profile      # optional: nono profile name (informational)
+//	custom_paths:
+//	  must_block:    []PathEntry
+//	  must_read:     []PathEntry
+//	  must_readwrite: []PathEntry
+//	  audit:         []PathEntry
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Severity levels for path expectations.
+type Severity string
+
+const (
+	SeverityCritical Severity = "critical"
+	SeverityError    Severity = "error"
+	SeverityWarn     Severity = "warn"
+)
+
+// CheckOp names for per-path operation overrides.
+type CheckOp string
+
+const (
+	OpStat    CheckOp = "stat"
+	OpReaddir CheckOp = "readdir"
+	OpOpen    CheckOp = "open"
+	OpWrite   CheckOp = "write"
+)
+
+// PathEntry describes a single path expectation.
+type PathEntry struct {
+	// Path is the filesystem path to probe.
+	Path string `yaml:"path"`
+	// Label is a short identifier used in findings and output.
+	Label string `yaml:"label"`
+	// Severity applies to must_block and must_read/must_readwrite violations.
+	Severity Severity `yaml:"severity"`
+	// Reason is a human-readable explanation included in findings.
+	Reason string `yaml:"reason"`
+	// Note is used for audit entries (no pass/fail).
+	Note string `yaml:"note"`
+	// CheckFiles are individual file names to probe inside this directory
+	// (must_block only: each file is checked for open=denied).
+	CheckFiles []string `yaml:"check_files"`
+	// CheckOps restricts which operations are tested. When empty all relevant
+	// ops for the category are tested.
+	CheckOps []CheckOp `yaml:"check_ops"`
+	// StatMayFail marks paths that may not exist on all machines (no failure
+	// if stat returns ENOENT).
+	StatMayFail bool `yaml:"stat_may_fail"`
+}
+
+// CustomPaths holds the four path categories.
+type CustomPaths struct {
+	MustBlock     []PathEntry `yaml:"must_block"`
+	MustRead      []PathEntry `yaml:"must_read"`
+	MustReadWrite []PathEntry `yaml:"must_readwrite"`
+	Audit         []PathEntry `yaml:"audit"`
+}
+
+// Identity describes the sandbox identity context (informational).
+type Identity struct {
+	SandboxUser  string `yaml:"sandbox_user"`
+	SandboxUID   int    `yaml:"sandbox_uid"`
+	HostUser     string `yaml:"host_user"`
+	HostUID      int    `yaml:"host_uid"`
+	SharedGID    int    `yaml:"shared_gid"`
+	NonoProfile  string `yaml:"nono_profile"`
+}
+
+// Config is the top-level config file structure.
+type Config struct {
+	Identity    Identity    `yaml:"identity"`
+	CustomPaths CustomPaths `yaml:"custom_paths"`
+}
+
+// LoadConfig reads and parses a YAML config file.
+// Returns nil, nil when path is empty (no config provided).
+func LoadConfig(path string) (*Config, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config %q: %w", path, err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config %q: %w", path, err)
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("invalid config %q: %w", path, err)
+	}
+
+	return &cfg, nil
+}
+
+// validate performs basic sanity checks on the loaded config.
+func (c *Config) validate() error {
+	allEntries := append(append(append(
+		c.CustomPaths.MustBlock,
+		c.CustomPaths.MustRead...),
+		c.CustomPaths.MustReadWrite...),
+		c.CustomPaths.Audit...)
+
+	for _, e := range allEntries {
+		if e.Path == "" {
+			return fmt.Errorf("path entry with label %q has empty path", e.Label)
+		}
+		for _, op := range e.CheckOps {
+			switch op {
+			case OpStat, OpReaddir, OpOpen, OpWrite:
+				// valid
+			default:
+				return fmt.Errorf("path %q has unknown check_op %q", e.Path, op)
+			}
+		}
+		switch e.Severity {
+		case SeverityCritical, SeverityError, SeverityWarn, "":
+			// valid (audit entries have no severity)
+		default:
+			return fmt.Errorf("path %q has unknown severity %q", e.Path, e.Severity)
+		}
+	}
+	return nil
+}
+
+// HasOp returns true when the entry has no CheckOps override (all ops apply)
+// or when the given op is explicitly listed.
+func (e *PathEntry) HasOp(op CheckOp) bool {
+	if len(e.CheckOps) == 0 {
+		return true
+	}
+	for _, o := range e.CheckOps {
+		if o == op {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -152,7 +152,7 @@ func validateEntries(category string, entries []PathEntry, severityRequired bool
 		if e.Path == "" {
 			return fmt.Errorf("%s path entry with label %q has empty path", category, e.Label)
 		}
-		if !filepath.IsAbs(e.Path) {
+		if !isAbsolutePath(e.Path) {
 			return fmt.Errorf("%s path %q must be absolute", category, e.Path)
 		}
 		for _, op := range e.CheckOps {
@@ -192,6 +192,19 @@ func isKnownCheckOp(op CheckOp) bool {
 	default:
 		return false
 	}
+}
+
+// isAbsolutePath accepts absolute paths for the host platform as well as the
+// standard POSIX and Windows forms. Config files are commonly authored on one
+// platform and validated in CI on another.
+func isAbsolutePath(path string) bool {
+	if filepath.IsAbs(path) || len(path) == 0 {
+		return filepath.IsAbs(path)
+	}
+	if path[0] == '/' {
+		return true
+	}
+	return len(path) >= 3 && ((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) && path[1] == ':' && (path[2] == '\\' || path[2] == '/')
 }
 
 // HasOp returns true when the entry has no CheckOps override (all ops apply)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -204,6 +204,9 @@ func isAbsolutePath(path string) bool {
 	if path[0] == '/' {
 		return true
 	}
+	if len(path) >= 2 && path[0] == '\\' && path[1] == '\\' {
+		return true
+	}
 	return len(path) >= 3 && ((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) && path[1] == ':' && (path[2] == '\\' || path[2] == '/')
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,8 +17,11 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -75,12 +78,12 @@ type CustomPaths struct {
 
 // Identity describes the sandbox identity context (informational).
 type Identity struct {
-	SandboxUser  string `yaml:"sandbox_user"`
-	SandboxUID   int    `yaml:"sandbox_uid"`
-	HostUser     string `yaml:"host_user"`
-	HostUID      int    `yaml:"host_uid"`
-	SharedGID    int    `yaml:"shared_gid"`
-	NonoProfile  string `yaml:"nono_profile"`
+	SandboxUser string `yaml:"sandbox_user"`
+	SandboxUID  int    `yaml:"sandbox_uid"`
+	HostUser    string `yaml:"host_user"`
+	HostUID     int    `yaml:"host_uid"`
+	SharedGID   int    `yaml:"shared_gid"`
+	NonoProfile string `yaml:"nono_profile"`
 }
 
 // Config is the top-level config file structure.
@@ -102,7 +105,15 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing config %q: %w", path, err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("parsing config %q: multiple YAML documents are not supported", path)
+		}
 		return nil, fmt.Errorf("parsing config %q: %w", path, err)
 	}
 
@@ -115,32 +126,72 @@ func LoadConfig(path string) (*Config, error) {
 
 // validate performs basic sanity checks on the loaded config.
 func (c *Config) validate() error {
-	allEntries := append(append(append(
-		c.CustomPaths.MustBlock,
-		c.CustomPaths.MustRead...),
-		c.CustomPaths.MustReadWrite...),
-		c.CustomPaths.Audit...)
+	paths := c.CustomPaths
+	if len(paths.MustBlock)+len(paths.MustRead)+len(paths.MustReadWrite)+len(paths.Audit) == 0 {
+		return fmt.Errorf("custom_paths must contain at least one path entry")
+	}
+	if err := validateEntries("must_block", paths.MustBlock, true, OpReaddir, OpOpen, OpWrite); err != nil {
+		return err
+	}
+	if err := validateEntries("must_read", paths.MustRead, true, OpStat, OpReaddir, OpOpen); err != nil {
+		return err
+	}
+	if err := validateEntries("must_readwrite", paths.MustReadWrite, true, OpStat, OpReaddir, OpOpen, OpWrite); err != nil {
+		return err
+	}
+	return validateEntries("audit", paths.Audit, false, OpStat, OpReaddir, OpOpen, OpWrite)
+}
 
-	for _, e := range allEntries {
+func validateEntries(category string, entries []PathEntry, severityRequired bool, allowedOps ...CheckOp) error {
+	allowed := make(map[CheckOp]struct{}, len(allowedOps))
+	for _, op := range allowedOps {
+		allowed[op] = struct{}{}
+	}
+
+	for _, e := range entries {
 		if e.Path == "" {
-			return fmt.Errorf("path entry with label %q has empty path", e.Label)
+			return fmt.Errorf("%s path entry with label %q has empty path", category, e.Label)
+		}
+		if !filepath.IsAbs(e.Path) {
+			return fmt.Errorf("%s path %q must be absolute", category, e.Path)
 		}
 		for _, op := range e.CheckOps {
-			switch op {
-			case OpStat, OpReaddir, OpOpen, OpWrite:
-				// valid
-			default:
+			if !isKnownCheckOp(op) {
 				return fmt.Errorf("path %q has unknown check_op %q", e.Path, op)
+			}
+			if _, ok := allowed[op]; !ok {
+				return fmt.Errorf("%s path %q does not support check_op %q", category, e.Path, op)
+			}
+		}
+		if category != "must_block" && len(e.CheckFiles) > 0 {
+			return fmt.Errorf("%s path %q cannot use check_files", category, e.Path)
+		}
+		for _, file := range e.CheckFiles {
+			if file == "" || file == "." || filepath.IsAbs(file) || filepath.Base(file) != file {
+				return fmt.Errorf("must_block path %q has invalid check_file %q", e.Path, file)
 			}
 		}
 		switch e.Severity {
-		case SeverityCritical, SeverityError, SeverityWarn, "":
-			// valid (audit entries have no severity)
+		case SeverityCritical, SeverityError, SeverityWarn:
+			// valid
+		case "":
+			if severityRequired {
+				return fmt.Errorf("%s path %q is missing severity", category, e.Path)
+			}
 		default:
 			return fmt.Errorf("path %q has unknown severity %q", e.Path, e.Severity)
 		}
 	}
 	return nil
+}
+
+func isKnownCheckOp(op CheckOp) bool {
+	switch op {
+	case OpStat, OpReaddir, OpOpen, OpWrite:
+		return true
+	default:
+		return false
+	}
 }
 
 // HasOp returns true when the entry has no CheckOps override (all ops apply)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,190 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+func TestLoadConfig_empty_path(t *testing.T) {
+	cfg, err := LoadConfig("")
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestLoadConfig_missing_file(t *testing.T) {
+	_, err := LoadConfig("/nonexistent/path/config.yaml")
+	assert.Error(t, err)
+}
+
+func TestLoadConfig_invalid_yaml(t *testing.T) {
+	path := writeConfig(t, ":\tinvalid: yaml: {{{")
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+}
+
+func TestLoadConfig_minimal(t *testing.T) {
+	path := writeConfig(t, `
+identity:
+  sandbox_user: alice
+  sandbox_uid: 1001
+  host_user: bob
+  host_uid: 1000
+custom_paths:
+  must_block:
+    - path: /home/bob/.ssh
+      label: ssh_keys
+      severity: critical
+      reason: "SSH private keys"
+`)
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, "alice", cfg.Identity.SandboxUser)
+	assert.Equal(t, 1001, cfg.Identity.SandboxUID)
+	assert.Equal(t, "bob", cfg.Identity.HostUser)
+
+	require.Len(t, cfg.CustomPaths.MustBlock, 1)
+	e := cfg.CustomPaths.MustBlock[0]
+	assert.Equal(t, "/home/bob/.ssh", e.Path)
+	assert.Equal(t, "ssh_keys", e.Label)
+	assert.Equal(t, SeverityCritical, e.Severity)
+}
+
+func TestLoadConfig_all_categories(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_block:
+    - path: /home/bob/.ssh
+      label: ssh
+      severity: critical
+      reason: keys
+  must_read:
+    - path: /usr/bin
+      label: usr_bin
+      reason: binaries
+  must_readwrite:
+    - path: /tmp/workspace
+      label: workspace
+      reason: cwd
+  audit:
+    - path: /home/bob
+      label: host_home
+      note: "stat leaks existence"
+`)
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	assert.Len(t, cfg.CustomPaths.MustBlock, 1)
+	assert.Len(t, cfg.CustomPaths.MustRead, 1)
+	assert.Len(t, cfg.CustomPaths.MustReadWrite, 1)
+	assert.Len(t, cfg.CustomPaths.Audit, 1)
+	assert.Equal(t, "stat leaks existence", cfg.CustomPaths.Audit[0].Note)
+}
+
+func TestLoadConfig_check_ops_override(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_block:
+    - path: /usr/local/src
+      label: usr_local_src
+      severity: warn
+      reason: read ok, write must be denied
+      check_ops: [readdir, open, write]
+`)
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	e := cfg.CustomPaths.MustBlock[0]
+	assert.True(t, e.HasOp(OpReaddir))
+	assert.True(t, e.HasOp(OpOpen))
+	assert.True(t, e.HasOp(OpWrite))
+	assert.False(t, e.HasOp(OpStat))
+}
+
+func TestLoadConfig_check_files(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_block:
+    - path: /home/bob/.ssh
+      label: ssh
+      severity: critical
+      reason: keys
+      check_files:
+        - id_rsa
+        - id_ed25519
+`)
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id_rsa", "id_ed25519"}, cfg.CustomPaths.MustBlock[0].CheckFiles)
+}
+
+func TestLoadConfig_unknown_severity(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_block:
+    - path: /foo
+      label: foo
+      severity: catastrophic
+      reason: bad
+`)
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown severity")
+}
+
+func TestLoadConfig_unknown_check_op(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_block:
+    - path: /foo
+      label: foo
+      severity: error
+      reason: bad
+      check_ops: [readdir, explode]
+`)
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown check_op")
+}
+
+func TestLoadConfig_empty_path_in_entry(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_block:
+    - label: noop
+      severity: error
+      reason: missing path
+`)
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty path")
+}
+
+func TestLoadConfig_realfile(t *testing.T) {
+	// Test against the public example config bundled with the repo.
+	realFile := filepath.Join("..", "..", "tests", "example", "alice-sandbox.yaml")
+	if _, err := os.Stat(realFile); os.IsNotExist(err) {
+		t.Skip("alice-sandbox.yaml not present — run from repo root")
+	}
+	cfg, err := LoadConfig(realFile)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "alice", cfg.Identity.SandboxUser)
+	assert.NotEmpty(t, cfg.CustomPaths.MustBlock)
+	assert.NotEmpty(t, cfg.CustomPaths.MustRead)
+	assert.NotEmpty(t, cfg.CustomPaths.MustReadWrite)
+	assert.NotEmpty(t, cfg.CustomPaths.Audit)
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -36,6 +36,100 @@ func TestLoadConfig_invalid_yaml(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestLoadConfig_rejectsUnknownFields(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_blocks:
+    - path: /home/bob/.ssh
+      label: ssh_keys
+      severity: critical
+`)
+
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+}
+
+func TestLoadConfig_requiresAtLeastOneCustomPath(t *testing.T) {
+	path := writeConfig(t, `
+identity:
+  sandbox_user: alice
+custom_paths: {}
+`)
+
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+}
+
+func TestLoadConfig_rejectsMultipleDocuments(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  audit:
+    - path: /tmp
+      label: temporary
+---
+custom_paths:
+  audit:
+    - path: /var/tmp
+      label: other
+`)
+
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+}
+
+func TestLoadConfig_rejectsCheckOpsUnsupportedByCategory(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_read:
+    - path: /tmp
+      label: temporary
+      severity: error
+      check_ops: [write]
+`)
+
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+}
+
+func TestLoadConfig_rejectsEscapingCheckFiles(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_block:
+    - path: /tmp
+      label: temporary
+      severity: critical
+      check_files: [../outside]
+`)
+
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+}
+
+func TestLoadConfig_rejectsRelativePaths(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_block:
+    - path: ../host/.ssh
+      label: ssh
+      severity: critical
+`)
+
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+}
+
+func TestLoadConfig_requiresSeverityForExpectations(t *testing.T) {
+	path := writeConfig(t, `
+custom_paths:
+  must_block:
+    - path: /tmp
+      label: temporary
+`)
+
+	_, err := LoadConfig(path)
+	assert.Error(t, err)
+}
+
 func TestLoadConfig_minimal(t *testing.T) {
 	path := writeConfig(t, `
 identity:
@@ -76,10 +170,12 @@ custom_paths:
   must_read:
     - path: /usr/bin
       label: usr_bin
+      severity: error
       reason: binaries
   must_readwrite:
     - path: /tmp/workspace
       label: workspace
+      severity: error
       reason: cwd
   audit:
     - path: /home/bob

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -118,6 +118,21 @@ custom_paths:
 	assert.Error(t, err)
 }
 
+func TestIsAbsolutePath(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{path: "/home/bob/.ssh", want: true},
+		{path: `C:\Users\bob\.ssh`, want: true},
+		{path: `D:/Users/bob/.ssh`, want: true},
+		{path: "relative/path", want: false},
+		{path: `C:relative\path`, want: false},
+	} {
+		assert.Equal(t, tc.want, isAbsolutePath(tc.path), tc.path)
+	}
+}
+
 func TestLoadConfig_requiresSeverityForExpectations(t *testing.T) {
 	path := writeConfig(t, `
 custom_paths:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -126,6 +126,7 @@ func TestIsAbsolutePath(t *testing.T) {
 		{path: "/home/bob/.ssh", want: true},
 		{path: `C:\Users\bob\.ssh`, want: true},
 		{path: `D:/Users/bob/.ssh`, want: true},
+		{path: `\\server\share\bob\.ssh`, want: true},
 		{path: "relative/path", want: false},
 		{path: `C:relative\path`, want: false},
 	} {

--- a/pkg/probes/probes.go
+++ b/pkg/probes/probes.go
@@ -3,6 +3,7 @@ package probes
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	reportv1 "github.com/controlplaneio/sandbox-probe/api/gen/proto/report/v1"
 	"github.com/controlplaneio/sandbox-probe/pkg/tasks"
@@ -26,19 +27,22 @@ func (p *Probe) Run() error {
 		return noTasksErr
 	}
 
+	var taskErrors []error
 	for idx, task := range p.Tasks {
 		log.Info().Msgf("Running task (%d/%d) %s", idx, len(p.Tasks), task.GetName())
 		findings, err := task.Run(context.TODO(), tasks.Inputs{
 			Fast: p.Fast,
 		})
+		p.Findings = append(p.Findings, findings...)
 		if err != nil {
 			log.Warn().Msgf("Error running task '%s': %s", task.GetName(), err)
-		} else {
-			p.Findings = append(p.Findings, findings...)
+			if tasks.IsScanFailure(err) {
+				taskErrors = append(taskErrors, fmt.Errorf("task %q: %w", task.GetName(), err))
+			}
 		}
 	}
 
-	return nil
+	return errors.Join(taskErrors...)
 }
 
 func NewProbe(opts ...NewProbeOpt) (*Probe, error) {

--- a/pkg/probes/probes_test.go
+++ b/pkg/probes/probes_test.go
@@ -1,0 +1,43 @@
+package probes
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	reportv1 "github.com/controlplaneio/sandbox-probe/api/gen/proto/report/v1"
+	"github.com/controlplaneio/sandbox-probe/pkg/tasks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type failingTask struct{}
+
+func (failingTask) GetName() string        { return "failing" }
+func (failingTask) GetDescription() string { return "returns an error" }
+func (failingTask) Run(context.Context, tasks.Inputs) ([]*reportv1.Finding, error) {
+	return []*reportv1.Finding{{FindingType: "test"}}, tasks.NewScanFailure(errors.New("expected failure"))
+}
+
+func TestProbeRunPropagatesTaskErrors(t *testing.T) {
+	probe, err := NewProbe(WithTasks([]tasks.Task{failingTask{}}))
+	require.NoError(t, err)
+
+	assert.Error(t, probe.Run())
+	assert.Len(t, probe.Findings, 1)
+}
+
+type optionalFailingTask struct{}
+
+func (optionalFailingTask) GetName() string        { return "optional-failing" }
+func (optionalFailingTask) GetDescription() string { return "returns a non-fatal error" }
+func (optionalFailingTask) Run(context.Context, tasks.Inputs) ([]*reportv1.Finding, error) {
+	return nil, errors.New("expected optional failure")
+}
+
+func TestProbeRunDoesNotPropagateNonFatalTaskErrors(t *testing.T) {
+	probe, err := NewProbe(WithTasks([]tasks.Task{optionalFailingTask{}}))
+	require.NoError(t, err)
+
+	assert.NoError(t, probe.Run())
+}

--- a/pkg/tasks/baseline/custom_paths.go
+++ b/pkg/tasks/baseline/custom_paths.go
@@ -1,0 +1,209 @@
+package tasks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/controlplaneio/sandbox-probe/pkg/config"
+)
+
+// CheckResult holds the outcome of probing a single path entry.
+type CheckResult struct {
+	Entry    config.PathEntry
+	Category string // "must_block" | "must_read" | "must_readwrite" | "audit"
+
+	StatOK    bool
+	ReaddirOK bool
+	OpenOK    bool
+	WriteOK   bool
+
+	// Violations is non-empty for must_* categories when an op fails its
+	// expectation. Empty for audit entries.
+	Violations []Violation
+}
+
+// Violation records a single failing operation check.
+type Violation struct {
+	Op       config.CheckOp
+	Expected bool // true = expected accessible, false = expected denied
+	Got      bool // actual result
+	Severity config.Severity
+	Message  string
+}
+
+// CheckCustomPaths runs all four categories from the config and returns
+// one CheckResult per path entry (plus one per check_files sub-entry).
+func CheckCustomPaths(cfg *config.Config) []CheckResult {
+	var results []CheckResult
+
+	for _, e := range cfg.CustomPaths.MustBlock {
+		results = append(results, checkMustBlock(e))
+		// Per-file checks inside the directory
+		for _, fname := range e.CheckFiles {
+			filePath := filepath.Join(e.Path, fname)
+			fileEntry := config.PathEntry{
+				Path:     filePath,
+				Label:    e.Label + "/" + fname,
+				Severity: e.Severity,
+				Reason:   e.Reason,
+			}
+			results = append(results, checkMustBlockFile(fileEntry))
+		}
+	}
+
+	for _, e := range cfg.CustomPaths.MustRead {
+		results = append(results, checkMustRead(e))
+	}
+
+	for _, e := range cfg.CustomPaths.MustReadWrite {
+		results = append(results, checkMustReadWrite(e))
+	}
+
+	for _, e := range cfg.CustomPaths.Audit {
+		results = append(results, auditPath(e))
+	}
+
+	return results
+}
+
+// checkMustBlock: readdir=denied AND open=denied (write=denied too).
+// stat visibility is acceptable (VFS path existence leak) — documented as info.
+func checkMustBlock(e config.PathEntry) CheckResult {
+	r := CheckResult{Entry: e, Category: "must_block"}
+	r.StatOK = canStat(e.Path)
+	r.ReaddirOK = e.HasOp(config.OpReaddir) && canReaddir(e.Path)
+	r.OpenOK = e.HasOp(config.OpOpen) && canOpen(e.Path)
+	r.WriteOK = e.HasOp(config.OpWrite) && canWrite(e.Path)
+
+	if e.HasOp(config.OpReaddir) && r.ReaddirOK {
+		r.Violations = append(r.Violations, Violation{
+			Op:       config.OpReaddir,
+			Expected: false,
+			Got:      true,
+			Severity: e.Severity,
+			Message:  fmt.Sprintf("readdir() ALLOWED on %s — %s", e.Label, e.Reason),
+		})
+	}
+	if e.HasOp(config.OpOpen) && r.OpenOK {
+		r.Violations = append(r.Violations, Violation{
+			Op:       config.OpOpen,
+			Expected: false,
+			Got:      true,
+			Severity: e.Severity,
+			Message:  fmt.Sprintf("open() ALLOWED on %s — %s", e.Label, e.Reason),
+		})
+	}
+	if e.HasOp(config.OpWrite) && r.WriteOK {
+		r.Violations = append(r.Violations, Violation{
+			Op:       config.OpWrite,
+			Expected: false,
+			Got:      true,
+			Severity: e.Severity,
+			Message:  fmt.Sprintf("write() ALLOWED on %s — %s", e.Label, e.Reason),
+		})
+	}
+	return r
+}
+
+// checkMustBlockFile: individual file inside a must_block dir.
+// Only checks open() (readdir is already covered by the parent dir check).
+func checkMustBlockFile(e config.PathEntry) CheckResult {
+	r := CheckResult{Entry: e, Category: "must_block_file"}
+	r.StatOK = canStat(e.Path)
+	r.OpenOK = canOpen(e.Path)
+
+	if r.OpenOK {
+		r.Violations = append(r.Violations, Violation{
+			Op:       config.OpOpen,
+			Expected: false,
+			Got:      true,
+			Severity: e.Severity,
+			Message:  fmt.Sprintf("file open() ALLOWED: %s — %s", e.Label, e.Reason),
+		})
+	}
+	return r
+}
+
+// checkMustRead: readdir=ok required.
+func checkMustRead(e config.PathEntry) CheckResult {
+	r := CheckResult{Entry: e, Category: "must_read"}
+	r.StatOK = canStat(e.Path)
+	r.ReaddirOK = canReaddir(e.Path)
+
+	if !r.ReaddirOK {
+		r.Violations = append(r.Violations, Violation{
+			Op:       config.OpReaddir,
+			Expected: true,
+			Got:      false,
+			Severity: e.Severity,
+			Message:  fmt.Sprintf("readdir() DENIED on %s — expected readable: %s", e.Label, e.Reason),
+		})
+	}
+	return r
+}
+
+// checkMustReadWrite: readdir=ok AND write=ok required.
+func checkMustReadWrite(e config.PathEntry) CheckResult {
+	r := CheckResult{Entry: e, Category: "must_readwrite"}
+	r.StatOK = canStat(e.Path)
+	r.ReaddirOK = canReaddir(e.Path)
+	r.WriteOK = canWrite(e.Path)
+
+	if !r.ReaddirOK {
+		r.Violations = append(r.Violations, Violation{
+			Op:       config.OpReaddir,
+			Expected: true,
+			Got:      false,
+			Severity: e.Severity,
+			Message:  fmt.Sprintf("readdir() DENIED on %s — expected readable: %s", e.Label, e.Reason),
+		})
+	}
+	if !r.WriteOK {
+		r.Violations = append(r.Violations, Violation{
+			Op:       config.OpWrite,
+			Expected: true,
+			Got:      false,
+			Severity: e.Severity,
+			Message:  fmt.Sprintf("write() DENIED on %s — expected writable: %s", e.Label, e.Reason),
+		})
+	}
+	return r
+}
+
+// auditPath: probe all ops, no pass/fail verdict.
+func auditPath(e config.PathEntry) CheckResult {
+	return CheckResult{
+		Entry:     e,
+		Category:  "audit",
+		StatOK:    canStat(e.Path),
+		ReaddirOK: canReaddir(e.Path),
+		OpenOK:    canOpen(e.Path),
+		WriteOK:   canWrite(e.Path),
+		// Violations intentionally empty — audit has no pass/fail
+	}
+}
+
+// ── Low-level probes ──────────────────────────────────────────────────────
+// canStat/canReaddir wrap stdlib directly; canOpen/canWrite delegate to the
+// existing isReadable/isWritable helpers in filesystem.go (same package).
+
+func canStat(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func canReaddir(path string) bool {
+	entries, err := os.ReadDir(path)
+	// A non-nil error means denied (or not a dir). An empty dir is fine.
+	_ = entries
+	return err == nil
+}
+
+func canOpen(path string) bool {
+	return isReadable(path)
+}
+
+func canWrite(path string) bool {
+	return isWritable(path)
+}

--- a/pkg/tasks/baseline/custom_paths.go
+++ b/pkg/tasks/baseline/custom_paths.go
@@ -1,7 +1,9 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -39,7 +41,9 @@ func CheckCustomPaths(cfg *config.Config) []CheckResult {
 
 	for _, e := range cfg.CustomPaths.MustBlock {
 		results = append(results, checkMustBlock(e))
-		// Per-file checks inside the directory
+		// Per-file checks inside the directory.
+		// CheckOps is propagated so that a user-specified check_ops override on
+		// the parent directory entry is respected for the per-file open checks too.
 		for _, fname := range e.CheckFiles {
 			filePath := filepath.Join(e.Path, fname)
 			fileEntry := config.PathEntry{
@@ -47,6 +51,7 @@ func CheckCustomPaths(cfg *config.Config) []CheckResult {
 				Label:    e.Label + "/" + fname,
 				Severity: e.Severity,
 				Reason:   e.Reason,
+				CheckOps: e.CheckOps,
 			}
 			results = append(results, checkMustBlockFile(fileEntry))
 		}
@@ -72,11 +77,11 @@ func CheckCustomPaths(cfg *config.Config) []CheckResult {
 func checkMustBlock(e config.PathEntry) CheckResult {
 	r := CheckResult{Entry: e, Category: "must_block"}
 	r.StatOK = canStat(e.Path)
-	r.ReaddirOK = e.HasOp(config.OpReaddir) && canReaddir(e.Path)
-	r.OpenOK = e.HasOp(config.OpOpen) && canOpen(e.Path)
-	r.WriteOK = e.HasOp(config.OpWrite) && canWrite(e.Path)
+	r.ReaddirOK = shouldCheck(e, config.OpReaddir, config.OpReaddir, config.OpOpen, config.OpWrite) && canReaddir(e.Path)
+	r.OpenOK = shouldCheck(e, config.OpOpen, config.OpReaddir, config.OpOpen, config.OpWrite) && canOpen(e.Path)
+	r.WriteOK = shouldCheck(e, config.OpWrite, config.OpReaddir, config.OpOpen, config.OpWrite) && canWrite(e.Path)
 
-	if e.HasOp(config.OpReaddir) && r.ReaddirOK {
+	if shouldCheck(e, config.OpReaddir, config.OpReaddir, config.OpOpen, config.OpWrite) && r.ReaddirOK {
 		r.Violations = append(r.Violations, Violation{
 			Op:       config.OpReaddir,
 			Expected: false,
@@ -85,7 +90,7 @@ func checkMustBlock(e config.PathEntry) CheckResult {
 			Message:  fmt.Sprintf("readdir() ALLOWED on %s — %s", e.Label, e.Reason),
 		})
 	}
-	if e.HasOp(config.OpOpen) && r.OpenOK {
+	if shouldCheck(e, config.OpOpen, config.OpReaddir, config.OpOpen, config.OpWrite) && r.OpenOK {
 		r.Violations = append(r.Violations, Violation{
 			Op:       config.OpOpen,
 			Expected: false,
@@ -94,7 +99,7 @@ func checkMustBlock(e config.PathEntry) CheckResult {
 			Message:  fmt.Sprintf("open() ALLOWED on %s — %s", e.Label, e.Reason),
 		})
 	}
-	if e.HasOp(config.OpWrite) && r.WriteOK {
+	if shouldCheck(e, config.OpWrite, config.OpReaddir, config.OpOpen, config.OpWrite) && r.WriteOK {
 		r.Violations = append(r.Violations, Violation{
 			Op:       config.OpWrite,
 			Expected: false,
@@ -108,12 +113,14 @@ func checkMustBlock(e config.PathEntry) CheckResult {
 
 // checkMustBlockFile: individual file inside a must_block dir.
 // Only checks open() (readdir is already covered by the parent dir check).
+// Respects CheckOps: if the parent entry explicitly excluded OpOpen via
+// check_ops, no open violation is raised for per-file entries either.
 func checkMustBlockFile(e config.PathEntry) CheckResult {
 	r := CheckResult{Entry: e, Category: "must_block_file"}
 	r.StatOK = canStat(e.Path)
-	r.OpenOK = canOpen(e.Path)
+	r.OpenOK = shouldCheck(e, config.OpOpen, config.OpOpen) && canOpen(e.Path)
 
-	if r.OpenOK {
+	if shouldCheck(e, config.OpOpen, config.OpOpen) && r.OpenOK {
 		r.Violations = append(r.Violations, Violation{
 			Op:       config.OpOpen,
 			Expected: false,
@@ -125,49 +132,36 @@ func checkMustBlockFile(e config.PathEntry) CheckResult {
 	return r
 }
 
-// checkMustRead: readdir=ok required.
+// checkMustRead verifies the configured read operations. By default it checks
+// readdir; check_ops can select stat, readdir, or open explicitly.
 func checkMustRead(e config.PathEntry) CheckResult {
 	r := CheckResult{Entry: e, Category: "must_read"}
 	r.StatOK = canStat(e.Path)
-	r.ReaddirOK = canReaddir(e.Path)
 
-	if !r.ReaddirOK {
-		r.Violations = append(r.Violations, Violation{
-			Op:       config.OpReaddir,
-			Expected: true,
-			Got:      false,
-			Severity: e.Severity,
-			Message:  fmt.Sprintf("readdir() DENIED on %s — expected readable: %s", e.Label, e.Reason),
-		})
+	if statMayFail(e) {
+		return r
 	}
+
+	r.ReaddirOK = shouldCheck(e, config.OpReaddir, config.OpReaddir) && canReaddir(e.Path)
+	r.OpenOK = shouldCheck(e, config.OpOpen, config.OpReaddir) && canOpen(e.Path)
+	appendAccessibilityViolations(&r, e, config.OpStat, r.StatOK, config.OpReaddir, r.ReaddirOK, config.OpOpen, r.OpenOK)
 	return r
 }
 
-// checkMustReadWrite: readdir=ok AND write=ok required.
+// checkMustReadWrite verifies the configured read-write operations. By default
+// it checks readdir and write; check_ops can select individual operations.
 func checkMustReadWrite(e config.PathEntry) CheckResult {
 	r := CheckResult{Entry: e, Category: "must_readwrite"}
 	r.StatOK = canStat(e.Path)
-	r.ReaddirOK = canReaddir(e.Path)
-	r.WriteOK = canWrite(e.Path)
 
-	if !r.ReaddirOK {
-		r.Violations = append(r.Violations, Violation{
-			Op:       config.OpReaddir,
-			Expected: true,
-			Got:      false,
-			Severity: e.Severity,
-			Message:  fmt.Sprintf("readdir() DENIED on %s — expected readable: %s", e.Label, e.Reason),
-		})
+	if statMayFail(e) {
+		return r
 	}
-	if !r.WriteOK {
-		r.Violations = append(r.Violations, Violation{
-			Op:       config.OpWrite,
-			Expected: true,
-			Got:      false,
-			Severity: e.Severity,
-			Message:  fmt.Sprintf("write() DENIED on %s — expected writable: %s", e.Label, e.Reason),
-		})
-	}
+
+	r.ReaddirOK = shouldCheck(e, config.OpReaddir, config.OpReaddir, config.OpWrite) && canReaddir(e.Path)
+	r.OpenOK = shouldCheck(e, config.OpOpen, config.OpReaddir, config.OpWrite) && canOpen(e.Path)
+	r.WriteOK = shouldCheck(e, config.OpWrite, config.OpReaddir, config.OpWrite) && canWrite(e.Path)
+	appendAccessibilityViolations(&r, e, config.OpStat, r.StatOK, config.OpReaddir, r.ReaddirOK, config.OpOpen, r.OpenOK, config.OpWrite, r.WriteOK)
 	return r
 }
 
@@ -176,10 +170,10 @@ func auditPath(e config.PathEntry) CheckResult {
 	return CheckResult{
 		Entry:     e,
 		Category:  "audit",
-		StatOK:    canStat(e.Path),
-		ReaddirOK: canReaddir(e.Path),
-		OpenOK:    canOpen(e.Path),
-		WriteOK:   canWrite(e.Path),
+		StatOK:    shouldCheck(e, config.OpStat, config.OpStat, config.OpReaddir, config.OpOpen, config.OpWrite) && canStat(e.Path),
+		ReaddirOK: shouldCheck(e, config.OpReaddir, config.OpStat, config.OpReaddir, config.OpOpen, config.OpWrite) && canReaddir(e.Path),
+		OpenOK:    shouldCheck(e, config.OpOpen, config.OpStat, config.OpReaddir, config.OpOpen, config.OpWrite) && canOpen(e.Path),
+		WriteOK:   shouldCheck(e, config.OpWrite, config.OpStat, config.OpReaddir, config.OpOpen, config.OpWrite) && canWrite(e.Path),
 		// Violations intentionally empty — audit has no pass/fail
 	}
 }
@@ -191,6 +185,54 @@ func auditPath(e config.PathEntry) CheckResult {
 func canStat(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+func statMayFail(e config.PathEntry) bool {
+	if !e.StatMayFail {
+		return false
+	}
+	_, err := os.Stat(e.Path)
+	return errors.Is(err, fs.ErrNotExist)
+}
+
+func shouldCheck(e config.PathEntry, op config.CheckOp, defaults ...config.CheckOp) bool {
+	if len(e.CheckOps) > 0 {
+		return e.HasOp(op)
+	}
+	for _, defaultOp := range defaults {
+		if op == defaultOp {
+			return true
+		}
+	}
+	return false
+}
+
+func appendAccessibilityViolations(r *CheckResult, e config.PathEntry, operations ...interface{}) {
+	for i := 0; i < len(operations); i += 2 {
+		op := operations[i].(config.CheckOp)
+		got := operations[i+1].(bool)
+		if !shouldCheck(e, op, defaultOpsFor(r.Category)...) || got {
+			continue
+		}
+		r.Violations = append(r.Violations, Violation{
+			Op:       op,
+			Expected: true,
+			Got:      false,
+			Severity: e.Severity,
+			Message:  fmt.Sprintf("%s() DENIED on %s — expected accessible: %s", op, e.Label, e.Reason),
+		})
+	}
+}
+
+func defaultOpsFor(category string) []config.CheckOp {
+	switch category {
+	case "must_read":
+		return []config.CheckOp{config.OpReaddir}
+	case "must_readwrite":
+		return []config.CheckOp{config.OpReaddir, config.OpWrite}
+	default:
+		return nil
+	}
 }
 
 func canReaddir(path string) bool {

--- a/pkg/tasks/baseline/custom_paths_test.go
+++ b/pkg/tasks/baseline/custom_paths_test.go
@@ -1,0 +1,107 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/controlplaneio/sandbox-probe/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCustomPathsHonorsCheckOpsForMustRead(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "readable-file")
+	require.NoError(t, os.WriteFile(file, []byte("contents"), 0600))
+
+	results := CheckCustomPaths(&config.Config{CustomPaths: config.CustomPaths{
+		MustRead: []config.PathEntry{{
+			Path:     file,
+			Label:    "readable-file",
+			Severity: config.SeverityError,
+			CheckOps: []config.CheckOp{config.OpOpen},
+		}},
+	}})
+
+	require.Len(t, results, 1)
+	assert.True(t, results[0].OpenOK)
+	assert.Empty(t, results[0].Violations)
+}
+
+func TestCheckCustomPathsHonorsCheckOpsForMustReadWrite(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "readable-writable-file")
+	require.NoError(t, os.WriteFile(file, []byte("contents"), 0600))
+
+	results := CheckCustomPaths(&config.Config{CustomPaths: config.CustomPaths{
+		MustReadWrite: []config.PathEntry{{
+			Path:     file,
+			Label:    "readable-writable-file",
+			Severity: config.SeverityError,
+			CheckOps: []config.CheckOp{config.OpOpen},
+		}},
+	}})
+
+	require.Len(t, results, 1)
+	assert.True(t, results[0].OpenOK)
+	assert.Empty(t, results[0].Violations)
+}
+
+func TestCheckCustomPathsStatMayFailSkipsOnlyMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	results := CheckCustomPaths(&config.Config{CustomPaths: config.CustomPaths{
+		MustRead: []config.PathEntry{{
+			Path:        missing,
+			Label:       "optional-read-path",
+			Severity:    config.SeverityError,
+			StatMayFail: true,
+		}},
+		MustReadWrite: []config.PathEntry{{
+			Path:        missing,
+			Label:       "optional-readwrite-path",
+			Severity:    config.SeverityError,
+			StatMayFail: true,
+		}},
+	}})
+
+	require.Len(t, results, 2)
+	assert.Empty(t, results[0].Violations)
+	assert.Empty(t, results[1].Violations)
+}
+
+func TestCheckCustomPathsCheckFilesRespectsCheckOps(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secret"), []byte("secret"), 0600))
+
+	results := CheckCustomPaths(&config.Config{CustomPaths: config.CustomPaths{
+		MustBlock: []config.PathEntry{{
+			Path:       dir,
+			Label:      "protected-dir",
+			Severity:   config.SeverityCritical,
+			CheckFiles: []string{"secret"},
+			CheckOps:   []config.CheckOp{config.OpReaddir},
+		}},
+	}})
+
+	require.Len(t, results, 2)
+	assert.Len(t, results[0].Violations, 1, "the configured readdir check should run")
+	assert.Empty(t, results[1].Violations, "check_files must not probe open when open is excluded")
+}
+
+func TestCheckCustomPathsAuditRespectsCheckOps(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "audit-file")
+	require.NoError(t, os.WriteFile(file, []byte("contents"), 0600))
+
+	results := CheckCustomPaths(&config.Config{CustomPaths: config.CustomPaths{
+		Audit: []config.PathEntry{{
+			Path:     file,
+			Label:    "audit-file",
+			CheckOps: []config.CheckOp{config.OpStat},
+		}},
+	}})
+
+	require.Len(t, results, 1)
+	assert.True(t, results[0].StatOK)
+	assert.False(t, results[0].ReaddirOK)
+	assert.False(t, results[0].OpenOK)
+	assert.False(t, results[0].WriteOK)
+}

--- a/pkg/tasks/baseline/environment.go
+++ b/pkg/tasks/baseline/environment.go
@@ -180,6 +180,10 @@ func GetContainerRuntime(tgid, pid int) ContainerRuntime {
 	if fileExistsFunc("/.dockerenv") {
 		return RuntimeDocker
 	}
+	// Podman creates this marker in both rootful and rootless containers.
+	if fileExistsFunc("/run/.containerenv") {
+		return RuntimePodman
+	}
 
 	// OpenVZ detection
 	if fileExistsFunc("/proc/vz") && !fileExistsFunc("/proc/bc") {

--- a/pkg/tasks/baseline/environment_test.go
+++ b/pkg/tasks/baseline/environment_test.go
@@ -165,6 +165,25 @@ func Test_getContainerRuntime(t *testing.T) {
 	}
 }
 
+func TestGetContainerRuntimeDetectsPodmanMarker(t *testing.T) {
+	origRead, origExists, origLandlock, origChroot := readFile, fileExistsFunc, probeForLandlock, isChroot
+	t.Cleanup(func() {
+		readFile = origRead
+		fileExistsFunc = origExists
+		probeForLandlock = origLandlock
+		isChroot = origChroot
+	})
+
+	readFile = func(string) ([]byte, error) { return []byte("0::/"), nil }
+	fileExistsFunc = func(path string) bool { return path == "/run/.containerenv" }
+	probeForLandlock = func() (bool, error) { return false, nil }
+	isChroot = func() bool { return false }
+
+	if got := GetContainerRuntime(0, 0); got != RuntimePodman {
+		t.Fatalf("expected podman for /run/.containerenv, got %v", got)
+	}
+}
+
 func TestGetContainerRuntimeAppArmor(t *testing.T) {
 	origRead, origAttr, origExists, origLandlock, origChroot := readFile, readProcAttr, fileExistsFunc, probeForLandlock, isChroot
 	t.Cleanup(func() {

--- a/pkg/tasks/baseline/filesystem.go
+++ b/pkg/tasks/baseline/filesystem.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -34,7 +35,7 @@ func buildSensitivePaths() []SensitivePath {
 // buildSensitivePathsForHome is the testable core: it builds the path list
 // using the provided home directory instead of calling os.UserHomeDir().
 func buildSensitivePathsForHome(home string) []SensitivePath {
-	h := func(p string) string { return home + p }
+	h := func(p string) string { return filepath.Join(home, p) }
 
 	return []SensitivePath{
 		// ── User and group information ────────────────────────────────────

--- a/pkg/tasks/baseline/filesystem.go
+++ b/pkg/tasks/baseline/filesystem.go
@@ -3,7 +3,6 @@ package tasks
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -34,123 +33,72 @@ func buildSensitivePaths() []SensitivePath {
 
 // buildSensitivePathsForHome is the testable core: it builds the path list
 // using the provided home directory instead of calling os.UserHomeDir().
+// buildSensitivePathsForHome returns the full list of credential paths to scan.
+// It combines platform-specific absolute paths (from platformSensitivePaths,
+// defined per-platform in filesystem_unix.go / filesystem_windows.go) with
+// home-relative paths that are meaningful on every OS.
 func buildSensitivePathsForHome(home string) []SensitivePath {
 	h := func(p string) string { return filepath.Join(home, p) }
 
-	return []SensitivePath{
-		// ── User and group information ────────────────────────────────────
-		sp("/etc/passwd"),
-		sp("/etc/shadow"),
-		sp("/etc/group"),
-		sp("/etc/gshadow"),
-
-		// ── System configuration ──────────────────────────────────────────
-		sp("/etc/hostname"),
-		sp("/etc/hosts"),
-		sp("/etc/resolv.conf"),
-		sp("/etc/ssh/sshd_config"),
-		sp("/etc/sudoers"),
-
-		// ── Process and container information ─────────────────────────────
-		sp("/proc/self/cgroup"),
-		sp("/proc/self/mountinfo"),
-		sp("/proc/self/status"),
-		sp("/proc/1/cgroup"),
-		sp("/proc/1/environ"),
-
-		// ── Container runtime indicators ──────────────────────────────────
-		sp("/.dockerenv"),
-		sp("/run/.containerenv"),
-		sp("/var/run/docker.sock"),
-
-		// ── Root account credentials ──────────────────────────────────────
-		sp("/root"),
-		sp("/root/.ssh"),
-		sp("/root/.bash_history"),
-
-		// ── System credentials and keys ───────────────────────────────────
-		sp("/etc/ssl/private"),
-		sp("/etc/pki/private"),
-		sp("/var/lib/docker"),
-
-		// ── Runtime secrets (Docker / Kubernetes) ─────────────────────────
-		sp("/run/secrets"),
-		sp("/var/run/secrets/kubernetes.io/serviceaccount/token"),
-		sp("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"),
-
-		// ── SSH keys (current user) ───────────────────────────────────────
-		sp(h("/.ssh/id_rsa")),
-		sp(h("/.ssh/id_ed25519")),
-		sp(h("/.ssh/id_ecdsa")),
-		sp(h("/.ssh/config")),
-		sp(h("/.ssh/authorized_keys")),
+	// Cross-platform home-relative credential paths.
+	// filepath.Join handles the separator on every OS; os.Stat silently skips
+	// any path that doesn't exist on the current platform.
+	homePaths := []SensitivePath{
+		// ── SSH keys ──────────────────────────────────────────────────────
+		sp(h(".ssh/id_rsa")),
+		sp(h(".ssh/id_ed25519")),
+		sp(h(".ssh/id_ecdsa")),
+		sp(h(".ssh/config")),
+		sp(h(".ssh/authorized_keys")),
 
 		// ── Cloud credentials ─────────────────────────────────────────────
-		sp(h("/.aws/credentials")),
-		sp(h("/.aws/config")),
-		sp(h("/.gcloud/credentials.db")),
-		sp(h("/.gcloud/access_tokens.db")),
-		sp(h("/.config/gcloud")),
-		sp(h("/.azure/credentials")),
-		sp(h("/.azure/msal_token_cache.json")),
+		sp(h(".aws/credentials")),
+		sp(h(".aws/config")),
+		sp(h(".gcloud/credentials.db")),
+		sp(h(".gcloud/access_tokens.db")),
+		sp(h(".config/gcloud")),
+		sp(h(".azure/credentials")),
+		sp(h(".azure/msal_token_cache.json")),
 
 		// ── Container / Kubernetes credentials ───────────────────────────
-		sp(h("/.kube/config")),
-		sp(h("/.docker/config.json")),
+		sp(h(".kube/config")),
+		sp(h(".docker/config.json")),
 
 		// ── Crypto / signing ──────────────────────────────────────────────
-		sp(h("/.gnupg")),
+		sp(h(".gnupg")),
 
 		// ── VCS credentials ───────────────────────────────────────────────
-		sp(h("/.git-credentials")),
-		sp(h("/.netrc")),
+		sp(h(".git-credentials")),
+		sp(h(".netrc")),
 		// Only flag .gitconfig when it contains a [credential] section
-		spContains(h("/.gitconfig"), "[credential]"),
+		spContains(h(".gitconfig"), "[credential]"),
 
 		// ── Infrastructure / secrets management ───────────────────────────
-		sp(h("/.vault-token")),
-		sp(h("/.terraform.d/credentials.tfrc.json")),
-		sp(h("/.config/gh/hosts.yml")),
-		sp(h("/.config/op")),
-		sp(h("/.config/doctl/config.yaml")),
-		sp(h("/.fly/config.yml")),
-		sp(h("/.cloudflared")),
+		sp(h(".vault-token")),
+		sp(h(".terraform.d/credentials.tfrc.json")),
+		sp(h(".config/gh/hosts.yml")),
+		sp(h(".config/op")),
+		sp(h(".config/doctl/config.yaml")),
+		sp(h(".fly/config.yml")),
+		sp(h(".cloudflared")),
 
 		// ── Package manager tokens ────────────────────────────────────────
-		sp(h("/.npmrc")),
-		sp(h("/.pypirc")),
-		sp(h("/.gem/credentials")),
-		sp(h("/.cargo/credentials.toml")),
-		sp(h("/.m2/settings.xml")),
-		sp(h("/.gradle/gradle.properties")),
+		sp(h(".npmrc")),
+		sp(h(".pypirc")),
+		sp(h(".gem/credentials")),
+		sp(h(".cargo/credentials.toml")),
+		sp(h(".m2/settings.xml")),
+		sp(h(".gradle/gradle.properties")),
 	}
+
+	return append(platformSensitivePaths(home), homePaths...)
 }
 
-// System directories to check for write permissions (should typically be read-only)
-var SystemWritePaths = []string{
-	// Core system directories
-	"/etc",
-	"/boot",
-	"/usr",
-	"/usr/bin",
-	"/usr/sbin",
-	"/usr/lib",
-	"/bin",
-	"/sbin",
-	"/lib",
-	"/lib64",
-
-	// System state
-	"/sys",
-	"/proc",
-	"/dev",
-
-	// Variable data (some writable, some not)
-	"/var",
-	"/var/log",
-	"/var/lib",
-	"/opt",
-}
+// SystemWritePaths is the platform-specific list of system directories that
+// should be read-only. Defined per-platform in filesystem_unix.go /
+// filesystem_windows.go via the platformSystemWritePaths variable, then
+// exposed here for use by scanTargetedPathsForHome and tests.
+var SystemWritePaths = platformSystemWritePaths
 
 // PathPermissions holds lists of writable and readable paths
 type PathPermissions struct {
@@ -164,7 +112,7 @@ type PathPermissions struct {
 func ScanTargetedPaths() *PathPermissions {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		home = "/root"
+		home = platformDefaultHome()
 	}
 	return scanTargetedPathsForHome(home)
 }
@@ -175,11 +123,6 @@ func scanTargetedPathsForHome(home string) *PathPermissions {
 	result := &PathPermissions{
 		WritablePaths: make([]string, 0),
 		ReadablePaths: make([]string, 0),
-	}
-
-	// Unix-specific paths are not applicable on Windows
-	if runtime.GOOS == "windows" {
-		return result
 	}
 
 	// Check sensitive paths for read access

--- a/pkg/tasks/baseline/filesystem.go
+++ b/pkg/tasks/baseline/filesystem.go
@@ -14,8 +14,10 @@ type SensitivePath struct {
 	contains string // if set, file must contain this string to be reported
 }
 
-func sp(path string) SensitivePath                  { return SensitivePath{path: path} }
-func spContains(path, substr string) SensitivePath  { return SensitivePath{path: path, contains: substr} }
+func sp(path string) SensitivePath { return SensitivePath{path: path} }
+func spContains(path, substr string) SensitivePath {
+	return SensitivePath{path: path, contains: substr}
+}
 
 // sensitivePaths is populated at runtime (requires home dir expansion).
 // See buildSensitivePaths().

--- a/pkg/tasks/baseline/filesystem_sensitive_test.go
+++ b/pkg/tasks/baseline/filesystem_sensitive_test.go
@@ -101,6 +101,27 @@ func TestBuildSensitivePathsForHome_includesSystemPaths(t *testing.T) {
 		got[i] = p.path
 	}
 
+	if runtime.GOOS == "windows" {
+		// On Windows the Unix absolute paths are absent by design; assert
+		// Windows-specific credential stores are present instead.
+		windowsPaths := []string{
+			// These expand from %APPDATA% / %LOCALAPPDATA% on a real runner;
+			// since the test passes a synthetic home we just confirm the
+			// Windows Credential Manager and gcloud entries are included.
+			// The APPDATA-based entries are present when the env vars are set
+			// (they are on any real Windows host/CI runner).
+		}
+		for _, want := range windowsPaths {
+			assert.Contains(t, got, want, "windows path %q should be in list", want)
+		}
+		// Confirm Unix-only paths are correctly absent.
+		for _, absent := range []string{"/etc/passwd", "/var/run/docker.sock", "/run/secrets"} {
+			assert.NotContains(t, got, absent, "unix path %q must not appear on Windows", absent)
+		}
+		return
+	}
+
+	// Unix: assert the full set of absolute system paths.
 	system := []string{
 		"/etc/passwd", "/etc/shadow", "/etc/group", "/etc/gshadow",
 		"/etc/hostname", "/etc/hosts", "/etc/resolv.conf",

--- a/pkg/tasks/baseline/filesystem_sensitive_test.go
+++ b/pkg/tasks/baseline/filesystem_sensitive_test.go
@@ -56,37 +56,37 @@ func TestBuildSensitivePathsForHome_expandsHome(t *testing.T) {
 	}
 
 	homeRelative := []string{
-		home + "/.ssh/id_rsa",
-		home + "/.ssh/id_ed25519",
-		home + "/.ssh/id_ecdsa",
-		home + "/.ssh/config",
-		home + "/.ssh/authorized_keys",
-		home + "/.aws/credentials",
-		home + "/.aws/config",
-		home + "/.gcloud/credentials.db",
-		home + "/.gcloud/access_tokens.db",
-		home + "/.config/gcloud",
-		home + "/.azure/credentials",
-		home + "/.azure/msal_token_cache.json",
-		home + "/.kube/config",
-		home + "/.docker/config.json",
-		home + "/.gnupg",
-		home + "/.git-credentials",
-		home + "/.netrc",
-		home + "/.gitconfig",
-		home + "/.vault-token",
-		home + "/.terraform.d/credentials.tfrc.json",
-		home + "/.config/gh/hosts.yml",
-		home + "/.config/op",
-		home + "/.config/doctl/config.yaml",
-		home + "/.fly/config.yml",
-		home + "/.cloudflared",
-		home + "/.npmrc",
-		home + "/.pypirc",
-		home + "/.gem/credentials",
-		home + "/.cargo/credentials.toml",
-		home + "/.m2/settings.xml",
-		home + "/.gradle/gradle.properties",
+		filepath.Join(home, ".ssh", "id_rsa"),
+		filepath.Join(home, ".ssh", "id_ed25519"),
+		filepath.Join(home, ".ssh", "id_ecdsa"),
+		filepath.Join(home, ".ssh", "config"),
+		filepath.Join(home, ".ssh", "authorized_keys"),
+		filepath.Join(home, ".aws", "credentials"),
+		filepath.Join(home, ".aws", "config"),
+		filepath.Join(home, ".gcloud", "credentials.db"),
+		filepath.Join(home, ".gcloud", "access_tokens.db"),
+		filepath.Join(home, ".config", "gcloud"),
+		filepath.Join(home, ".azure", "credentials"),
+		filepath.Join(home, ".azure", "msal_token_cache.json"),
+		filepath.Join(home, ".kube", "config"),
+		filepath.Join(home, ".docker", "config.json"),
+		filepath.Join(home, ".gnupg"),
+		filepath.Join(home, ".git-credentials"),
+		filepath.Join(home, ".netrc"),
+		filepath.Join(home, ".gitconfig"),
+		filepath.Join(home, ".vault-token"),
+		filepath.Join(home, ".terraform.d", "credentials.tfrc.json"),
+		filepath.Join(home, ".config", "gh", "hosts.yml"),
+		filepath.Join(home, ".config", "op"),
+		filepath.Join(home, ".config", "doctl", "config.yaml"),
+		filepath.Join(home, ".fly", "config.yml"),
+		filepath.Join(home, ".cloudflared"),
+		filepath.Join(home, ".npmrc"),
+		filepath.Join(home, ".pypirc"),
+		filepath.Join(home, ".gem", "credentials"),
+		filepath.Join(home, ".cargo", "credentials.toml"),
+		filepath.Join(home, ".m2", "settings.xml"),
+		filepath.Join(home, ".gradle", "gradle.properties"),
 	}
 
 	for _, want := range homeRelative {
@@ -120,7 +120,7 @@ func TestBuildSensitivePathsForHome_gitconfigHasContentPredicate(t *testing.T) {
 	paths := buildSensitivePathsForHome(home)
 
 	for _, p := range paths {
-		if p.path == home+"/.gitconfig" {
+		if p.path == filepath.Join(home, ".gitconfig") {
 			assert.Equal(t, "[credential]", p.contains,
 				".gitconfig must carry a [credential] content predicate")
 			return
@@ -171,17 +171,13 @@ func TestScanTargetedPathsForHome_readableFileReported(t *testing.T) {
 
 	result := scanTargetedPathsForHome(home)
 
-	if runtime.GOOS == "windows" {
-		// On Windows, should return empty results
-		assert.Empty(t, result.ReadablePaths)
-		assert.Empty(t, result.WritablePaths)
-		return
-	}
-
 	assert.True(t, inReadable(result, target), ".aws/credentials should be reported")
 }
 
 func TestScanTargetedPathsForHome_unreadableFileNotReported(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 000 has no effect on Windows ACL-based permissions")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("chmod 000 has no effect as root")
 	}
@@ -214,13 +210,6 @@ func TestScanTargetedPathsForHome_gitconfigWithCredentialSection(t *testing.T) {
 
 	result := scanTargetedPathsForHome(home)
 
-	if runtime.GOOS == "windows" {
-		// On Windows, should return empty results
-		assert.Empty(t, result.ReadablePaths)
-		assert.Empty(t, result.WritablePaths)
-		return
-	}
-
 	assert.True(t, inReadable(result, gitconfig),
 		".gitconfig with [credential] should be reported")
 }
@@ -241,13 +230,6 @@ func TestScanTargetedPathsForHome_gitconfigContentCheckCaseInsensitive(t *testin
 	writeTestFile(t, gitconfig, "[CREDENTIAL]\n\thelper = store\n")
 
 	result := scanTargetedPathsForHome(home)
-
-	if runtime.GOOS == "windows" {
-		// On Windows, should return empty results
-		assert.Empty(t, result.ReadablePaths)
-		assert.Empty(t, result.WritablePaths)
-		return
-	}
 
 	assert.True(t, inReadable(result, gitconfig),
 		"content predicate must be case-insensitive")
@@ -279,13 +261,6 @@ func TestScanTargetedPathsForHome_sshKeys(t *testing.T) {
 
 	result := scanTargetedPathsForHome(home)
 
-	if runtime.GOOS == "windows" {
-		// On Windows, should return empty results
-		assert.Empty(t, result.ReadablePaths)
-		assert.Empty(t, result.WritablePaths)
-		return
-	}
-
 	for _, rel := range files {
 		assert.True(t, inReadable(result, filepath.Join(home, rel)), "%s should be reported", rel)
 	}
@@ -307,13 +282,6 @@ func TestScanTargetedPathsForHome_cloudCredentials(t *testing.T) {
 
 	result := scanTargetedPathsForHome(home)
 
-	if runtime.GOOS == "windows" {
-		// On Windows, should return empty results
-		assert.Empty(t, result.ReadablePaths)
-		assert.Empty(t, result.WritablePaths)
-		return
-	}
-
 	for _, rel := range files {
 		assert.True(t, inReadable(result, filepath.Join(home, rel)), "%s should be reported", rel)
 	}
@@ -325,13 +293,6 @@ func TestScanTargetedPathsForHome_containerCredentials(t *testing.T) {
 	writeTestFile(t, filepath.Join(home, ".docker", "config.json"), "{}\n")
 
 	result := scanTargetedPathsForHome(home)
-
-	if runtime.GOOS == "windows" {
-		// On Windows, should return empty results
-		assert.Empty(t, result.ReadablePaths)
-		assert.Empty(t, result.WritablePaths)
-		return
-	}
 
 	assert.True(t, inReadable(result, filepath.Join(home, ".kube", "config")))
 	assert.True(t, inReadable(result, filepath.Join(home, ".docker", "config.json")))
@@ -351,13 +312,6 @@ func TestScanTargetedPathsForHome_infraSecrets(t *testing.T) {
 	}
 
 	result := scanTargetedPathsForHome(home)
-
-	if runtime.GOOS == "windows" {
-		// On Windows, should return empty results
-		assert.Empty(t, result.ReadablePaths)
-		assert.Empty(t, result.WritablePaths)
-		return
-	}
 
 	for _, rel := range files {
 		assert.True(t, inReadable(result, filepath.Join(home, rel)), "%s should be reported", rel)
@@ -380,13 +334,6 @@ func TestScanTargetedPathsForHome_packageManagerTokens(t *testing.T) {
 
 	result := scanTargetedPathsForHome(home)
 
-	if runtime.GOOS == "windows" {
-		// On Windows, should return empty results
-		assert.Empty(t, result.ReadablePaths)
-		assert.Empty(t, result.WritablePaths)
-		return
-	}
-
 	for _, rel := range files {
 		assert.True(t, inReadable(result, filepath.Join(home, rel)), "%s should be reported", rel)
 	}
@@ -398,13 +345,6 @@ func TestScanTargetedPathsForHome_vcsCredentials(t *testing.T) {
 	writeTestFile(t, filepath.Join(home, ".netrc"), "placeholder\n")
 
 	result := scanTargetedPathsForHome(home)
-
-	if runtime.GOOS == "windows" {
-		// On Windows, should return empty results
-		assert.Empty(t, result.ReadablePaths)
-		assert.Empty(t, result.WritablePaths)
-		return
-	}
 
 	assert.True(t, inReadable(result, filepath.Join(home, ".git-credentials")))
 	assert.True(t, inReadable(result, filepath.Join(home, ".netrc")))
@@ -418,13 +358,6 @@ func TestScanTargetedPathsForHome_directoryPaths(t *testing.T) {
 	}
 
 	result := scanTargetedPathsForHome(home)
-
-	if runtime.GOOS == "windows" {
-		// On Windows, should return empty results
-		assert.Empty(t, result.ReadablePaths)
-		assert.Empty(t, result.WritablePaths)
-		return
-	}
 
 	for _, d := range dirs {
 		assert.True(t, inReadable(result, filepath.Join(home, d)),

--- a/pkg/tasks/baseline/filesystem_sensitive_test.go
+++ b/pkg/tasks/baseline/filesystem_sensitive_test.go
@@ -104,16 +104,34 @@ func TestBuildSensitivePathsForHome_includesSystemPaths(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// On Windows the Unix absolute paths are absent by design; assert
 		// Windows-specific credential stores are present instead.
-		windowsPaths := []string{
-			// These expand from %APPDATA% / %LOCALAPPDATA% on a real runner;
-			// since the test passes a synthetic home we just confirm the
-			// Windows Credential Manager and gcloud entries are included.
-			// The APPDATA-based entries are present when the env vars are set
-			// (they are on any real Windows host/CI runner).
+
+		// Positive assertions: APPDATA-based entries are present when the env
+		// vars are set (they always are on a real Windows host or CI runner).
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			windowsPaths := []string{
+				filepath.Join(appData, "Microsoft", "Credentials"),
+				filepath.Join(appData, "Microsoft", "Protect"),
+				filepath.Join(appData, "gcloud"),
+			}
+			for _, want := range windowsPaths {
+				assert.Contains(t, got, want, "windows APPDATA path %q should be in list", want)
+			}
+		} else {
+			t.Log("APPDATA not set — skipping Windows APPDATA positive assertions")
 		}
-		for _, want := range windowsPaths {
-			assert.Contains(t, got, want, "windows path %q should be in list", want)
+
+		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
+			windowsLocalPaths := []string{
+				filepath.Join(localAppData, "Google", "Cloud SDK", "application_default_credentials.json"),
+				filepath.Join(localAppData, "1Password"),
+			}
+			for _, want := range windowsLocalPaths {
+				assert.Contains(t, got, want, "windows LOCALAPPDATA path %q should be in list", want)
+			}
+		} else {
+			t.Log("LOCALAPPDATA not set — skipping Windows LOCALAPPDATA positive assertions")
 		}
+
 		// Confirm Unix-only paths are correctly absent.
 		for _, absent := range []string{"/etc/passwd", "/var/run/docker.sock", "/run/secrets"} {
 			assert.NotContains(t, got, absent, "unix path %q must not appear on Windows", absent)

--- a/pkg/tasks/baseline/filesystem_test.go
+++ b/pkg/tasks/baseline/filesystem_test.go
@@ -264,8 +264,15 @@ func TestPathConstants(t *testing.T) {
 		minCount int
 	}{
 		{
-			name:     "SensitiveReadPaths",
-			paths:    func() []string { ps := buildSensitivePaths(); out := make([]string, len(ps)); for i, p := range ps { out[i] = p.path }; return out }(),
+			name: "SensitiveReadPaths",
+			paths: func() []string {
+				ps := buildSensitivePaths()
+				out := make([]string, len(ps))
+				for i, p := range ps {
+					out[i] = p.path
+				}
+				return out
+			}(),
 			minCount: 10,
 		},
 		{

--- a/pkg/tasks/baseline/filesystem_unix.go
+++ b/pkg/tasks/baseline/filesystem_unix.go
@@ -40,3 +40,81 @@ func isWritable(path string) bool {
 	f.Close()
 	return true
 }
+
+// platformDefaultHome returns the fallback home directory when os.UserHomeDir fails.
+func platformDefaultHome() string {
+	return "/root"
+}
+
+// platformSensitivePaths returns Unix-specific absolute paths to check.
+// These paths don't exist on Windows and are meaningless there.
+func platformSensitivePaths(_ string) []SensitivePath {
+	return []SensitivePath{
+		// ── User and group information ────────────────────────────────────
+		sp("/etc/passwd"),
+		sp("/etc/shadow"),
+		sp("/etc/group"),
+		sp("/etc/gshadow"),
+
+		// ── System configuration ──────────────────────────────────────────
+		sp("/etc/hostname"),
+		sp("/etc/hosts"),
+		sp("/etc/resolv.conf"),
+		sp("/etc/ssh/sshd_config"),
+		sp("/etc/sudoers"),
+
+		// ── Process and container information ─────────────────────────────
+		sp("/proc/self/cgroup"),
+		sp("/proc/self/mountinfo"),
+		sp("/proc/self/status"),
+		sp("/proc/1/cgroup"),
+		sp("/proc/1/environ"),
+
+		// ── Container runtime indicators ──────────────────────────────────
+		sp("/.dockerenv"),
+		sp("/run/.containerenv"),
+		sp("/var/run/docker.sock"),
+
+		// ── Root account credentials ──────────────────────────────────────
+		sp("/root"),
+		sp("/root/.ssh"),
+		sp("/root/.bash_history"),
+
+		// ── System credentials and keys ───────────────────────────────────
+		sp("/etc/ssl/private"),
+		sp("/etc/pki/private"),
+		sp("/var/lib/docker"),
+
+		// ── Runtime secrets (Docker / Kubernetes) ─────────────────────────
+		sp("/run/secrets"),
+		sp("/var/run/secrets/kubernetes.io/serviceaccount/token"),
+		sp("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"),
+	}
+}
+
+// platformSystemWritePaths is the Unix list of system directories that
+// should be read-only under normal operation.
+var platformSystemWritePaths = []string{
+	// Core system directories
+	"/etc",
+	"/boot",
+	"/usr",
+	"/usr/bin",
+	"/usr/sbin",
+	"/usr/lib",
+	"/bin",
+	"/sbin",
+	"/lib",
+	"/lib64",
+
+	// System state
+	"/sys",
+	"/proc",
+	"/dev",
+
+	// Variable data (some writable, some not)
+	"/var",
+	"/var/log",
+	"/var/lib",
+	"/opt",
+}

--- a/pkg/tasks/baseline/filesystem_unix.go
+++ b/pkg/tasks/baseline/filesystem_unix.go
@@ -22,14 +22,20 @@ func isReadable(path string) bool {
 }
 
 func isWritable(path string) bool {
-	if err := unix.Access(path, unix.W_OK); err != nil {
-		return false
-	}
-	// Directories cannot be opened with O_WRONLY; unix.Access is sufficient.
 	info, err := os.Stat(path)
 	if err != nil {
 		return false
 	}
+	accessMode := uint32(unix.W_OK)
+	if info.IsDir() {
+		// POSIX requires write and search permission to create or remove a
+		// directory entry; W_OK alone is not sufficient for a usable workspace.
+		accessMode |= unix.X_OK
+	}
+	if err := unix.Access(path, accessMode); err != nil {
+		return false
+	}
+	// Directories cannot be opened with O_WRONLY; Access above is sufficient.
 	if info.IsDir() {
 		return true
 	}

--- a/pkg/tasks/baseline/filesystem_unix_test.go
+++ b/pkg/tasks/baseline/filesystem_unix_test.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package tasks
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsWritableDirectoryRequiresSearchPermission(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0200))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	assert.False(t, isWritable(dir))
+}

--- a/pkg/tasks/baseline/filesystem_windows.go
+++ b/pkg/tasks/baseline/filesystem_windows.go
@@ -5,6 +5,7 @@ package tasks
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 )
 
@@ -68,4 +69,66 @@ func isWritable(path string) bool {
 	}
 	f.Close()
 	return true
+}
+
+// platformDefaultHome returns the fallback home directory when os.UserHomeDir fails.
+func platformDefaultHome() string {
+	// On Windows, C:\Users\Default is the closest equivalent to /root.
+	return filepath.Join(os.Getenv("SystemDrive"), "Users", "Default")
+}
+
+// platformSensitivePaths returns Windows-specific absolute paths to check.
+// These are credential stores and sensitive locations that exist on Windows
+// but have no Unix equivalent (and vice versa for the Unix list).
+func platformSensitivePaths(home string) []SensitivePath {
+	appData := os.Getenv("APPDATA")         // C:\Users\<name>\AppData\Roaming
+	localAppData := os.Getenv("LOCALAPPDATA") // C:\Users\<name>\AppData\Local
+
+	var paths []SensitivePath
+
+	if appData != "" {
+		paths = append(paths,
+			// ── Windows Credential Manager / generic stores ───────────────
+			sp(filepath.Join(appData, "Microsoft", "Credentials")),
+			sp(filepath.Join(appData, "Microsoft", "Protect")),
+
+			// ── Cloud SDKs on Windows ─────────────────────────────────────
+			sp(filepath.Join(appData, "gcloud")),
+			sp(filepath.Join(appData, "doctl", "config.yaml")),
+		)
+	}
+
+	if localAppData != "" {
+		paths = append(paths,
+			// ── Local credential caches ───────────────────────────────────
+			sp(filepath.Join(localAppData, "Google", "Cloud SDK", "application_default_credentials.json")),
+
+			// ── 1Password / password manager local data ───────────────────
+			sp(filepath.Join(localAppData, "1Password")),
+		)
+	}
+
+	if home != "" {
+		paths = append(paths,
+			// ── OpenSSH for Windows stores keys in the same relative location ──
+			// (already covered by the cross-platform home-relative list in
+			// buildSensitivePathsForHome, included here for completeness)
+
+			// ── Windows Git Credential Manager ────────────────────────────
+			sp(filepath.Join(home, ".config", "git", "credentials")),
+		)
+	}
+
+	return paths
+}
+
+// platformSystemWritePaths lists Windows system directories that should be
+// read-only. The equivalent of /etc, /usr/bin etc. on Windows.
+var platformSystemWritePaths = []string{
+	// Windows system directories — these should never be writable by an AI agent.
+	`C:\Windows\System32`,
+	`C:\Windows\SysWOW64`,
+	`C:\Windows`,
+	`C:\Program Files`,
+	`C:\Program Files (x86)`,
 }

--- a/pkg/tasks/baseline/filesystem_windows.go
+++ b/pkg/tasks/baseline/filesystem_windows.go
@@ -74,14 +74,18 @@ func isWritable(path string) bool {
 // platformDefaultHome returns the fallback home directory when os.UserHomeDir fails.
 func platformDefaultHome() string {
 	// On Windows, C:\Users\Default is the closest equivalent to /root.
-	return filepath.Join(os.Getenv("SystemDrive"), "Users", "Default")
+	sd := os.Getenv("SystemDrive")
+	if sd == "" {
+		sd = "C:"
+	}
+	return filepath.Join(sd, "Users", "Default")
 }
 
 // platformSensitivePaths returns Windows-specific absolute paths to check.
 // These are credential stores and sensitive locations that exist on Windows
 // but have no Unix equivalent (and vice versa for the Unix list).
 func platformSensitivePaths(home string) []SensitivePath {
-	appData := os.Getenv("APPDATA")         // C:\Users\<name>\AppData\Roaming
+	appData := os.Getenv("APPDATA")           // C:\Users\<name>\AppData\Roaming
 	localAppData := os.Getenv("LOCALAPPDATA") // C:\Users\<name>\AppData\Local
 
 	var paths []SensitivePath

--- a/pkg/tasks/baseline/network.go
+++ b/pkg/tasks/baseline/network.go
@@ -2,11 +2,11 @@ package tasks
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -72,7 +72,7 @@ func ScanTCP(host string) []int {
 		go func() {
 			defer wg.Done()
 			for port := range ports {
-				address := fmt.Sprintf("%s:%d", host, port)
+				address := networkAddress(host, port)
 				conn, err := net.DialTimeout("tcp", address, timeout)
 				if err == nil {
 					results <- port
@@ -121,7 +121,7 @@ func ScanUDP(host string) []int {
 		go func() {
 			defer wg.Done()
 			for port := range ports {
-				address := fmt.Sprintf("%s:%d", host, port)
+				address := networkAddress(host, port)
 
 				conn, err := net.DialTimeout("udp", address, timeout)
 				if err != nil {
@@ -162,6 +162,10 @@ func ScanUDP(host string) []int {
 	}
 
 	return openPorts
+}
+
+func networkAddress(host string, port int) string {
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 func netErrTimeout(err error) bool {

--- a/pkg/tasks/baseline/network_address_test.go
+++ b/pkg/tasks/baseline/network_address_test.go
@@ -1,0 +1,23 @@
+package tasks
+
+import "testing"
+
+func TestNetworkAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		port int
+		want string
+	}{
+		{name: "hostname", host: "localhost", port: 443, want: "localhost:443"},
+		{name: "IPv4", host: "127.0.0.1", port: 53, want: "127.0.0.1:53"},
+		{name: "IPv6", host: "::1", port: 443, want: "[::1]:443"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := networkAddress(tt.host, tt.port); got != tt.want {
+				t.Fatalf("networkAddress(%q, %d) = %q, want %q", tt.host, tt.port, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tasks/baseline/processes_test.go
+++ b/pkg/tasks/baseline/processes_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 func TestStringToContainerRuntime(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/tasks/custom_paths_task.go
+++ b/pkg/tasks/custom_paths_task.go
@@ -1,0 +1,124 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	reportv1 "github.com/controlplaneio/sandbox-probe/api/gen/proto/report/v1"
+	"github.com/controlplaneio/sandbox-probe/pkg/config"
+	baselineTasks "github.com/controlplaneio/sandbox-probe/pkg/tasks/baseline"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	// FindingType for a path expectation violation (must_block / must_read / must_readwrite).
+	CUSTOMPATHVIOLATION = "custom_path_violation"
+	// FindingType for an audit-only path observation (no pass/fail).
+	CUSTOMPATHAUDIT = "custom_path_audit"
+)
+
+// CustomPathsTask runs the custom_paths checks defined in a config file.
+type CustomPathsTask struct {
+	baseTask
+	cfg *config.Config
+}
+
+// NewCustomPathsTask constructs a task from the loaded config.
+func NewCustomPathsTask(cfg *config.Config) *CustomPathsTask {
+	return &CustomPathsTask{
+		baseTask: baseTask{
+			name:        "custom_paths_checker",
+			description: "Checks filesystem paths against must_block/must_read/must_readwrite/audit declarations",
+		},
+		cfg: cfg,
+	}
+}
+
+func (t *CustomPathsTask) Run(_ context.Context, _ Inputs) ([]*reportv1.Finding, error) {
+	log.Info().Str("task", t.GetName()).Msg("Starting custom path checks")
+
+	results := baselineTasks.CheckCustomPaths(t.cfg)
+
+	var findings []*reportv1.Finding
+	for _, r := range results {
+		if r.Category == "audit" {
+			f, err := auditFinding(r)
+			if err != nil {
+				log.Warn().Err(err).Str("path", r.Entry.Path).Msg("Failed to build audit finding")
+				continue
+			}
+			findings = append(findings, f)
+			continue
+		}
+
+		if len(r.Violations) == 0 {
+			// Pass — no finding emitted for clean paths
+			continue
+		}
+
+		for _, v := range r.Violations {
+			f, err := violationFinding(r, v)
+			if err != nil {
+				log.Warn().Err(err).Str("path", r.Entry.Path).Msg("Failed to build violation finding")
+				continue
+			}
+			findings = append(findings, f)
+		}
+	}
+
+	log.Info().
+		Str("task", t.GetName()).
+		Int("results", len(results)).
+		Int("findings", len(findings)).
+		Msg("Custom path checks complete")
+
+	return findings, nil
+}
+
+func violationFinding(r baselineTasks.CheckResult, v baselineTasks.Violation) (*reportv1.Finding, error) {
+	detail := map[string]interface{}{
+		"path":     r.Entry.Path,
+		"label":    r.Entry.Label,
+		"category": r.Category,
+		"op":       string(v.Op),
+		"severity": string(v.Severity),
+		"expected": fmt.Sprintf("%v", v.Expected),
+		"got":      fmt.Sprintf("%v", v.Got),
+		"message":  v.Message,
+	}
+	val, err := structpb.NewValue(detail)
+	if err != nil {
+		return nil, err
+	}
+	return &reportv1.Finding{
+		FindingType: CUSTOMPATHVIOLATION,
+		Task:        "custom_paths_checker",
+		Description: fmt.Sprintf("[%s] %s", v.Severity, v.Message),
+		Value:       val,
+	}, nil
+}
+
+func auditFinding(r baselineTasks.CheckResult) (*reportv1.Finding, error) {
+	detail := map[string]interface{}{
+		"path":      r.Entry.Path,
+		"label":     r.Entry.Label,
+		"category":  "audit",
+		"stat":      r.StatOK,
+		"readdir":   r.ReaddirOK,
+		"open":      r.OpenOK,
+		"write":     r.WriteOK,
+		"note":      r.Entry.Note,
+	}
+	val, err := structpb.NewValue(detail)
+	if err != nil {
+		return nil, err
+	}
+	return &reportv1.Finding{
+		FindingType: CUSTOMPATHAUDIT,
+		Task:        "custom_paths_checker",
+		Description: fmt.Sprintf("[audit] %s (%s): stat=%v readdir=%v open=%v write=%v",
+			r.Entry.Label, r.Entry.Path, r.StatOK, r.ReaddirOK, r.OpenOK, r.WriteOK),
+		Value: val,
+	}, nil
+}

--- a/pkg/tasks/custom_paths_task.go
+++ b/pkg/tasks/custom_paths_task.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	reportv1 "github.com/controlplaneio/sandbox-probe/api/gen/proto/report/v1"
@@ -41,6 +42,7 @@ func (t *CustomPathsTask) Run(_ context.Context, _ Inputs) ([]*reportv1.Finding,
 	results := baselineTasks.CheckCustomPaths(t.cfg)
 
 	var findings []*reportv1.Finding
+	var failures []error
 	for _, r := range results {
 		if r.Category == "audit" {
 			f, err := auditFinding(r)
@@ -64,6 +66,9 @@ func (t *CustomPathsTask) Run(_ context.Context, _ Inputs) ([]*reportv1.Finding,
 				continue
 			}
 			findings = append(findings, f)
+			if v.Severity == config.SeverityCritical || v.Severity == config.SeverityError {
+				failures = append(failures, fmt.Errorf("[%s] %s", v.Severity, v.Message))
+			}
 		}
 	}
 
@@ -73,6 +78,9 @@ func (t *CustomPathsTask) Run(_ context.Context, _ Inputs) ([]*reportv1.Finding,
 		Int("findings", len(findings)).
 		Msg("Custom path checks complete")
 
+	if len(failures) > 0 {
+		return findings, NewScanFailure(fmt.Errorf("custom path expectations failed: %w", errors.Join(failures...)))
+	}
 	return findings, nil
 }
 
@@ -101,14 +109,14 @@ func violationFinding(r baselineTasks.CheckResult, v baselineTasks.Violation) (*
 
 func auditFinding(r baselineTasks.CheckResult) (*reportv1.Finding, error) {
 	detail := map[string]interface{}{
-		"path":      r.Entry.Path,
-		"label":     r.Entry.Label,
-		"category":  "audit",
-		"stat":      r.StatOK,
-		"readdir":   r.ReaddirOK,
-		"open":      r.OpenOK,
-		"write":     r.WriteOK,
-		"note":      r.Entry.Note,
+		"path":     r.Entry.Path,
+		"label":    r.Entry.Label,
+		"category": "audit",
+		"stat":     r.StatOK,
+		"readdir":  r.ReaddirOK,
+		"open":     r.OpenOK,
+		"write":    r.WriteOK,
+		"note":     r.Entry.Note,
 	}
 	val, err := structpb.NewValue(detail)
 	if err != nil {

--- a/pkg/tasks/custom_paths_task_test.go
+++ b/pkg/tasks/custom_paths_task_test.go
@@ -1,0 +1,41 @@
+package tasks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/controlplaneio/sandbox-probe/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomPathsTaskSeverityControlsFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		severity  config.Severity
+		wantError bool
+	}{
+		{name: "critical aborts", severity: config.SeverityCritical, wantError: true},
+		{name: "error fails scan", severity: config.SeverityError, wantError: true},
+		{name: "warn reports only", severity: config.SeverityWarn, wantError: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{CustomPaths: config.CustomPaths{
+				MustBlock: []config.PathEntry{{
+					Path:     t.TempDir(),
+					Label:    "readable-directory",
+					Severity: tc.severity,
+					Reason:   "test boundary",
+				}},
+			}}
+
+			findings, err := NewCustomPathsTask(cfg).Run(context.Background(), Inputs{})
+			require.NotEmpty(t, findings)
+			if tc.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -3,6 +3,7 @@ package tasks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -85,6 +86,34 @@ var taskSetRegistry = map[string]func() []Task{
 
 type Inputs struct {
 	Fast bool
+}
+
+// ScanFailure marks a task error that must make the overall scan fail after
+// the report has been produced. Ordinary task errors remain non-fatal so an
+// optional or platform-specific probe cannot invalidate an otherwise useful
+// report.
+type ScanFailure struct {
+	err error
+}
+
+func (e *ScanFailure) Error() string {
+	return e.err.Error()
+}
+
+func (e *ScanFailure) Unwrap() error {
+	return e.err
+}
+
+// NewScanFailure wraps a task error that must result in a non-zero scan exit.
+func NewScanFailure(err error) error {
+	return &ScanFailure{err: err}
+}
+
+// IsScanFailure reports whether err represents a task failure that must fail
+// the overall scan.
+func IsScanFailure(err error) bool {
+	var scanFailure *ScanFailure
+	return errors.As(err, &scanFailure)
 }
 
 type Task interface {

--- a/scripts/run-bwrap.sh
+++ b/scripts/run-bwrap.sh
@@ -1,12 +1,19 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# TODO: narrow down to just be able to run the executable
+set -euo pipefail
 
-cp $1 $2
+# shellcheck disable=SC1091 # dynamic script-relative helper path.
+source "$(dirname "$0")/runner-common.sh"
+validate_runner_inputs "$@" || exit $?
+PROBE=$1
+OUTDIR=$2
 
-cd $2
+cp "$PROBE" "$OUTDIR"
 
-BINARY_NAME=$(echo $1 | awk -F '/' '{print $NF}')
+cd "$OUTDIR" || exit
+
+BINARY_NAME=$(basename "$PROBE")
+WORKDIR=$(pwd)
 
 bwrap \
   --ro-bind /proc /proc \
@@ -16,7 +23,7 @@ bwrap \
   --ro-bind /bin /bin \
   --ro-bind /sbin /sbin \
   --ro-bind /etc /etc \
-  --bind $(pwd) /data \
+  --bind "$WORKDIR" /data \
   --bind /tmp /tmp \
   --chdir /data \
   --unshare-user \
@@ -25,4 +32,4 @@ bwrap \
   --unshare-cgroup \
   --share-net \
   --die-with-parent \
-  /data/${BINARY_NAME} scan --tasks baseline_sandbox_task --tasksets none
+  "/data/${BINARY_NAME}" scan --tasks baseline_sandbox_task --tasksets none

--- a/scripts/run-claude-sandbox.sh
+++ b/scripts/run-claude-sandbox.sh
@@ -1,14 +1,26 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 
+# shellcheck disable=SC1091 # dynamic script-relative helper path.
+source "$(dirname "$0")/runner-common.sh"
+validate_runner_inputs "$@" || exit $?
+PROBE=$1
+OUTDIR=$2
 
-cp $1 $2
+cp "$PROBE" "$OUTDIR"
 
-cd $2
+cd "$OUTDIR" || exit
 
 # TODO: narrow down to just be able to run the executable
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-VERSION=$(claude --version)
+CLAUDE_HOME="$(mktemp -d)"
+trap 'rm -rf "$CLAUDE_HOME"' EXIT
+mkdir -p "$CLAUDE_HOME/.claude"
+printf '{}\n' > "$CLAUDE_HOME/.claude/settings.json"
 
-claude --settings ${SCRIPT_DIR}/config/claude-settings.json --allowedTools "Bash" -p "Execute !$1 scan --tags version=${VERSION},tool=claude,sandbox=true" 
+VERSION=$(HOME="$CLAUDE_HOME" claude --version)
+
+HOME="$CLAUDE_HOME" claude --settings "${SCRIPT_DIR}/config/claude-settings.json" --allowedTools "Bash" -p "Execute !./$(basename "$PROBE") scan --tags version=${VERSION},tool=claude,sandbox=true"

--- a/scripts/run-claude.sh
+++ b/scripts/run-claude.sh
@@ -1,12 +1,16 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# TODO: narrow down to just be able to run the executable
+set -euo pipefail
 
+# shellcheck disable=SC1091 # dynamic script-relative helper path.
+source "$(dirname "$0")/runner-common.sh"
+validate_runner_inputs "$@" || exit $?
+PROBE=$1
+OUTDIR=$2
 
-cp $1 $2
-
-cd $2
+cp "$PROBE" "$OUTDIR"
+cd "$OUTDIR" || exit
 
 VERSION=$(claude --version)
 
-claude --allowedTools "Bash" -p "Execute !$1 scan --tags version=${VERSION},tool=claude" 
+claude --allowedTools "Bash" -p "Execute !./$(basename "$PROBE") scan --tags version=${VERSION},tool=claude"

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -1,11 +1,16 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# TODO: narrow down to just be able to run the executable
+set -euo pipefail
 
+# shellcheck disable=SC1091 # dynamic script-relative helper path.
+source "$(dirname "$0")/runner-common.sh"
+validate_runner_inputs "$@" || exit $?
+PROBE=$1
+OUTDIR=$2
 
-cp $1 $2
+cp "$PROBE" "$OUTDIR"
 
-cd $2
+cd "$OUTDIR" || exit
 
-
-docker run  -w /data/ --rm -it -v $(pwd):/data ubuntu:latest /data/$(echo $1 | awk -F '/' '{print $NF}') scan --tasks baseline_sandbox_task --tasksets none
+docker run -w /data/ --rm -v "$(pwd):/data" ubuntu:latest \
+  "/data/$(basename "$PROBE")" scan --tasks baseline_sandbox_task --tasksets none

--- a/scripts/run-gemini-interactive.sh
+++ b/scripts/run-gemini-interactive.sh
@@ -1,8 +1,15 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-cp $1 $2
+set -euo pipefail
 
-cd $2
+# shellcheck disable=SC1091 # dynamic script-relative helper path.
+source "$(dirname "$0")/runner-common.sh"
+validate_runner_inputs "$@" || exit $?
+PROBE=$1
+OUTDIR=$2
+
+cp "$PROBE" "$OUTDIR"
+cd "$OUTDIR" || exit
 
 VERSION=$(gemini --version)
 

--- a/scripts/run-gemini-podman-interactive.sh
+++ b/scripts/run-gemini-podman-interactive.sh
@@ -1,10 +1,15 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
+set -euo pipefail
 
+# shellcheck disable=SC1091 # dynamic script-relative helper path.
+source "$(dirname "$0")/runner-common.sh"
+validate_runner_inputs "$@" || exit $?
+PROBE=$1
+OUTDIR=$2
 
-cp $1 $2/sandbox-probe
-
-cd $2
+cp "$PROBE" "$OUTDIR/sandbox-probe"
+cd "$OUTDIR" || exit
 
 VERSION=$(gemini --version)
 

--- a/scripts/run-gemini-podman.sh
+++ b/scripts/run-gemini-podman.sh
@@ -1,17 +1,26 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
+# Run the real Gemini CLI through the deterministic local model stub. This
+# preserves the legacy report contract without requiring interactive input or a
+# user's Gemini configuration.
+set -euo pipefail
 
+# shellcheck disable=SC1091 # dynamic script-relative helper path.
+source "$(dirname "$0")/runner-common.sh"
+validate_runner_inputs "$@" || exit $?
+PROBE=$1
+OUTDIR=$2
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPORT="reports/sandbox-gemini-podman-$$.json"
 
-cp $1 $2/sandbox-probe
+trap 'rm -f "$PROJECT_ROOT/$REPORT"' EXIT
 
-cd $2
+mkdir -p "$OUTDIR"
+cd "$PROJECT_ROOT"
 
-VERSION=$(gemini --version)
+PROBE="$PROJECT_ROOT/$PROBE" OUT="$REPORT" RUNNER="$(uname -s)" \
+  GEMINI_SANDBOX=docker SCAN_ARGS="scan --tasksets baseline" \
+  bash "$PROJECT_ROOT/scripts/run-probe-via-gemini-stub.sh"
 
-printf "!!!! please ensure your ./bin/sandbox-probe is either statically linked\nor only links to standard locations /lib /lib64\nso it can run inside the podman sandbox"
-
-# gemini doesn't allow tool call of `run_shell_command` when using non interactive prompts
-# there is `--prompt-interactive` which can take a value but even with `--yolo`
-# gemini will wait for user input and won't quit
-# instead we pipe output into interaction
-printf "Execute \`./sandbox-probe scan --tags version=%s,tool=gemini\` take no further action and exit /quit\n\n\n\n" "$VERSION" | GEMINI_SANDBOX=podman gemini -y --sandbox
+cp "$REPORT" "$OUTDIR/report.json"

--- a/scripts/run-gemini.sh
+++ b/scripts/run-gemini.sh
@@ -1,8 +1,15 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-cp $1 $2
+set -euo pipefail
 
-cd $2
+# shellcheck disable=SC1091 # dynamic script-relative helper path.
+source "$(dirname "$0")/runner-common.sh"
+validate_runner_inputs "$@" || exit $?
+PROBE=$1
+OUTDIR=$2
+
+cp "$PROBE" "$OUTDIR"
+cd "$OUTDIR" || exit
 
 VERSION=$(gemini --version)
 

--- a/scripts/run-podman.sh
+++ b/scripts/run-podman.sh
@@ -1,11 +1,16 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# TODO: narrow down to just be able to run the executable
+set -euo pipefail
 
+# shellcheck disable=SC1091 # dynamic script-relative helper path.
+source "$(dirname "$0")/runner-common.sh"
+validate_runner_inputs "$@" || exit $?
+PROBE=$1
+OUTDIR=$2
 
-cp $1 $2
+cp "$PROBE" "$OUTDIR"
 
-cd $2
+cd "$OUTDIR" || exit
 
-
-podman run  -w /data/ --rm -it -v $(pwd):/data ubuntu:latest /data/$(echo $1 | awk -F '/' '{print $NF}') scan --tasks baseline_sandbox_task --tasksets none
+podman run -w /data/ --rm --env container=podman -v "$(pwd):/data" ubuntu:latest \
+  "/data/$(basename "$PROBE")" scan --tasks baseline_sandbox_task --tasksets none

--- a/scripts/run-probe-in-sandbox.sh
+++ b/scripts/run-probe-in-sandbox.sh
@@ -18,6 +18,7 @@ set -eo pipefail
 : "${RUNTIME:?RUNTIME (srt|firejail|nono|podman|docker|bwrap|nspawn|gvisor) is required}"
 RUNNER="${RUNNER:-$(uname -s)}"
 SCAN_ARGS="${SCAN_ARGS:-scan --tasksets baseline}"
+read -r -a SCAN_ARGV <<< "$SCAN_ARGS"
 
 mkdir -p "$(dirname "$OUT")"
 PROBE_ABS="$(cd "$(dirname "$PROBE")" && pwd)/$(basename "$PROBE")"
@@ -41,7 +42,7 @@ sandbox_version() {
 }
 RUNTIME_VERSION="$(sandbox_version "$RUNTIME")" || RUNTIME_VERSION=""
 TAGS="runner=${RUNNER},harness=${RUNTIME},${RUNTIME}=${RUNTIME_VERSION:-unknown},sandbox=on,mode=via-sandbox"
-CMD=("$PROBE_ABS" $SCAN_ARGS --tags "$TAGS" --output_path "$OUT_ABS")
+CMD=("$PROBE_ABS" "${SCAN_ARGV[@]}" --tags "$TAGS" --output_path "$OUT_ABS")
 
 # The container runtimes mount $PWD at /work and strip the $PWD prefix from the probe/report paths;
 # that only holds when both live under $PWD. Fail clearly otherwise (instead of a cryptic broken
@@ -73,13 +74,13 @@ JSON
     # the report lands back on the host. PROBE/OUT must be under $PWD (mounted at /work).
     require_under_pwd "$PROBE_ABS" PROBE; require_under_pwd "$OUT_ABS" OUT
     podman run --rm --network=none -v "$PWD:/work" -w /work docker.io/library/ubuntu:latest \
-      "/work/${PROBE_ABS#"$PWD"/}" $SCAN_ARGS --tags "$TAGS" --output_path "/work/${OUT_ABS#"$PWD"/}" </dev/null || true
+      "/work/${PROBE_ABS#"$PWD"/}" "${SCAN_ARGV[@]}" --tags "$TAGS" --output_path "/work/${OUT_ABS#"$PWD"/}" </dev/null || true
     ;;
   docker)
     # Same as podman but the Docker daemon; the probe fingerprints it as "docker".
     require_under_pwd "$PROBE_ABS" PROBE; require_under_pwd "$OUT_ABS" OUT
     docker run --rm --network=none -v "$PWD:/work" -w /work ubuntu:latest \
-      "/work/${PROBE_ABS#"$PWD"/}" $SCAN_ARGS --tags "$TAGS" --output_path "/work/${OUT_ABS#"$PWD"/}" </dev/null || true
+      "/work/${PROBE_ABS#"$PWD"/}" "${SCAN_ARGV[@]}" --tags "$TAGS" --output_path "/work/${OUT_ABS#"$PWD"/}" </dev/null || true
     ;;
   bwrap)
     # Standalone bubblewrap with bwrap left visible as the parent — the invocation the probe DOES
@@ -89,7 +90,7 @@ JSON
     bwrap --ro-bind /usr /usr --ro-bind /bin /bin --ro-bind-try /sbin /sbin \
       --ro-bind /lib /lib --ro-bind-try /lib64 /lib64 --ro-bind /etc /etc --proc /proc --dev /dev \
       --bind "$PWD" /work --chdir /work --unshare-user --unshare-ipc --unshare-uts --unshare-cgroup --die-with-parent \
-      "/work/${PROBE_ABS#"$PWD"/}" $SCAN_ARGS --tags "$TAGS" --output_path "/work/${OUT_ABS#"$PWD"/}" || true
+      "/work/${PROBE_ABS#"$PWD"/}" "${SCAN_ARGV[@]}" --tags "$TAGS" --output_path "/work/${OUT_ABS#"$PWD"/}" || true
     ;;
   nspawn)
     # ROOTFS is a prepared root filesystem (built by the workflow); copy the probe in and bind the
@@ -97,7 +98,7 @@ JSON
     : "${ROOTFS:?ROOTFS (prepared rootfs dir) is required for nspawn}"
     sudo cp "$PROBE_ABS" "$ROOTFS/probe"
     sudo systemd-nspawn -q -D "$ROOTFS" --bind="$(dirname "$OUT_ABS")" \
-      /probe $SCAN_ARGS --tags "$TAGS" --output_path "$OUT_ABS" </dev/null || true
+      /probe "${SCAN_ARGV[@]}" --tags "$TAGS" --output_path "$OUT_ABS" </dev/null || true
     ;;
   gvisor)
     # Full runsc container (systrap platform — no KVM needed) so /__runsc_containers__ exists ->
@@ -108,7 +109,7 @@ JSON
     OUTDIR="$(dirname "$OUT_ABS")"
     BUNDLE="$(mktemp -d)"
     ( cd "$BUNDLE" && runsc spec )
-    ARGS_JSON="$(printf '%s\n' /probe $SCAN_ARGS --tags "$TAGS" --output_path "$OUT_ABS" | jq -R . | jq -s .)"
+    ARGS_JSON="$(printf '%s\n' /probe "${SCAN_ARGV[@]}" --tags "$TAGS" --output_path "$OUT_ABS" | jq -R . | jq -s .)"
     TMPCFG="$(mktemp)"
     jq --arg root "$ROOTFS" --arg out "$OUTDIR" --argjson args "$ARGS_JSON" \
       '.root.path=$root | .process.args=$args | .process.terminal=false

--- a/scripts/run-probe-via-gemini-stub.sh
+++ b/scripts/run-probe-via-gemini-stub.sh
@@ -12,6 +12,7 @@
 # Optional env: GEMINI_SANDBOX (''|sandbox-exec|docker|podman), RUNNER, PORT, MODEL,
 #               SCAN_ARGS (default "scan --tasksets baseline").
 set -eo pipefail
+# shellcheck disable=SC1091 # dynamic script-relative shared helper path.
 source "$(dirname "$0")/stub-common.sh"
 
 PORT="${PORT:-8788}"
@@ -40,17 +41,25 @@ if [ "${GEMINI_SANDBOX:-}" = "docker" ] && command -v docker >/dev/null 2>&1; th
   DOCKER_VERSION="$(docker --version 2>/dev/null | awk 'NR==1{gsub(/,/,"",$3); print $3}')" || DOCKER_VERSION=""
   [ -n "$DOCKER_VERSION" ] && SANDBOX_TOOL_TAG=",docker=${DOCKER_VERSION}"
 fi
+# shellcheck disable=SC2034 # stub_start_mock consumes this contract variable.
 TAGS="runner=${RUNNER},harness=gemini,sandbox=${GEMINI_SANDBOX:-none},gemini=${VERSION}${SANDBOX_TOOL_TAG},mode=via-gemini-stub"
 
 # Bind/reach the mock differently for the container sandbox (whole CLI runs inside it).
 MOCK_HOST=127.0.0.1; BASE_HOST=localhost; SANDBOX_FLAG=()
 case "$GEMINI_SANDBOX" in
   docker|podman)
+    # shellcheck disable=SC2034 # stub_start_mock consumes this contract variable.
     MOCK_HOST=0.0.0.0; BASE_HOST=host.docker.internal; SANDBOX_FLAG=(--sandbox)
     export GEMINI_SANDBOX
     # The whole CLI re-execs inside the container: route the mock via host.docker.internal, and pass
     # through the key/base-URL + workspace trust so the mounted .gemini/settings.json auth is honoured.
     export SANDBOX_FLAGS="--add-host host.docker.internal:host-gateway --entrypoint \"\" -e GEMINI_CLI_TRUST_WORKSPACE=true -e GEMINI_API_KEY=dummy -e GOOGLE_GEMINI_BASE_URL=http://host.docker.internal:${PORT}"
+    if [ "$(uname -s)" = "Linux" ]; then
+      # Gemini CLI 0.40 rejects non-localhost HTTP base URLs before it launches
+      # Docker. Host networking retains mock reachability while using localhost.
+      BASE_HOST=localhost
+      export SANDBOX_FLAGS="--network host --entrypoint \"\" -e GEMINI_CLI_TRUST_WORKSPACE=true -e GEMINI_API_KEY=dummy -e GOOGLE_GEMINI_BASE_URL=http://localhost:${PORT}"
+    fi
     ;;
   sandbox-exec)
     SANDBOX_FLAG=(--sandbox); export GEMINI_SANDBOX ;;

--- a/scripts/run-probe-via-trae-stub.sh
+++ b/scripts/run-probe-via-trae-stub.sh
@@ -14,6 +14,7 @@
 # Optional env: RUNNER, PORT, SCAN_ARGS, TRAE_DOCKER (off|on), TRAE_SRC (trae-agent checkout dir),
 #               TRAE_CLI (trae-cli path), TRAE_DOCKER_IMAGE (default ubuntu:latest).
 set -eo pipefail
+# shellcheck disable=SC1091 # shellcheck cannot follow the dynamic script-relative source path.
 source "$(dirname "$0")/stub-common.sh"
 
 PORT="${PORT:-8794}"
@@ -27,7 +28,12 @@ stub_init
 PROBE_ABS="$(cd "$(dirname "$PROBE")" && pwd)/$(basename "$PROBE")"
 OUT_ABS="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")"
 # trae-cli's own venv bin on PATH so pyinstaller (docker mode) resolves.
-case "$TRAE_CLI" in */*) export PATH="$(cd "$(dirname "$TRAE_CLI")" && pwd):$PATH" ;; esac
+case "$TRAE_CLI" in
+  */*)
+    trae_bin_dir="$(cd "$(dirname "$TRAE_CLI")" && pwd)"
+    export PATH="$trae_bin_dir:$PATH"
+    ;;
+esac
 
 HARNESS=trae; [ "$TRAE_DOCKER" = "on" ] && HARNESS=trae-docker
 TAGS="runner=${RUNNER},harness=${HARNESS},trae=$(stub_semver "$TRAE_CLI" --version),mode=via-trae-stub"
@@ -42,6 +48,7 @@ if [ "$TRAE_DOCKER" = "on" ]; then
   PROBE_CMD="/workspace/probe ${SCAN_ARGS} --tags ${TAGS} --output_path /workspace/report.json"
   DOCKER_FLAGS=(--docker-image "$TRAE_DOCKER_IMAGE")
 else
+  # shellcheck disable=SC2034 # stub_start_mock consumes this contract variable.
   PROBE_CMD="${PROBE_ABS} ${SCAN_ARGS} --tags ${TAGS} --output_path ${OUT_ABS}"
   DOCKER_FLAGS=()
 fi

--- a/scripts/runner-common.sh
+++ b/scripts/runner-common.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Shared validation for legacy run-* harnesses.
+validate_runner_inputs() {
+  if [[ "$#" -ne 2 ]]; then
+    echo "usage: $0 PROBE OUTDIR" >&2
+    return 64
+  fi
+
+  local probe=$1 outdir=$2
+  if [[ ! -f "$probe" ]]; then
+    echo "ERROR: probe does not exist or is not a regular file: $probe" >&2
+    return 66
+  fi
+  if [[ ! -x "$probe" ]]; then
+    echo "ERROR: probe is not executable: $probe" >&2
+    return 66
+  fi
+  if [[ ! -d "$outdir" ]]; then
+    echo "ERROR: output directory does not exist: $outdir" >&2
+    return 73
+  fi
+}

--- a/tests/baseline_nono.sh
+++ b/tests/baseline_nono.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-mkdir -p $HOME/.sandbox-probe/tmp
-TMPDIR=$(mktemp -d -p $HOME/.sandbox-probe/tmp)
+mkdir -p "$HOME/.sandbox-probe/tmp"
+TMPDIR=$(mktemp -d -p "$HOME/.sandbox-probe/tmp")
 echo "created TMPDIR: $TMPDIR"
 
 # note, this isn't really the baseline, this is the most permissive nono
@@ -9,25 +9,28 @@ echo "created TMPDIR: $TMPDIR"
 # nono be baseline and then have a report for each profile
 echo "Testing no sandbox mode (extra permissive) with Nono"
 
-cp ./bin/sandbox-probe $TMPDIR/
+cp ./bin/sandbox-probe "$TMPDIR/"
 OLDDIR="$PWD"
-cd "$TMPDIR"
+cd "$TMPDIR" || exit
 
-# file needs to exist before nono allows access
-touch report.json
-
-nono run --silent --allow-cwd --allow / ./sandbox-probe scan
+# This is intentionally relaxed: it exposes the probe's runtime, system and
+# credential target paths while excluding nono's protected state root.
+PROFILE="$OLDDIR/tests/nono/relaxed-baseline.json"
+if ! nono run --silent --profile "$PROFILE" ./sandbox-probe scan; then
+    echo "ERROR: relaxed nono baseline could not initialize"
+    exit 1
+fi
 
 # Display the report
 if [ -f "$TMPDIR/report.json" ]; then
-    echo "\n=== Report Generated ==="
-    jq '.' $TMPDIR/report.json
+    printf '\n=== Report Generated ===\n'
+    jq '.' "$TMPDIR/report.json"
 else
     echo "ERROR: report.json not found"
     exit 1
 fi
 
-cd "$OLDDIR"
+cd "$OLDDIR" || exit
 
 mkdir -p ./reports
-cp $TMPDIR/report.json ./reports/baseline-nono.json
+cp "$TMPDIR/report.json" ./reports/baseline-nono.json

--- a/tests/detect_claude.sh
+++ b/tests/detect_claude.sh
@@ -32,8 +32,16 @@ mkdir -p reports
 OUT="reports/sandbox-claude.json"
 rm -f "$OUT"
 
+# Claude's Linux bubblewrap sandbox expects to create settings beneath HOME.
+# Isolate that state so this deterministic stub test never depends on a user's
+# real Claude configuration or writes into it.
+CLAUDE_HOME="$(mktemp -d)"
+trap 'rm -rf "$CLAUDE_HOME"' EXIT
+mkdir -p "$CLAUDE_HOME/.claude"
+printf '{}\n' > "$CLAUDE_HOME/.claude/settings.json"
+
 # Run only the sandbox-detector task for a fast check (the full baseline is slow).
-PROBE=./bin/sandbox-probe OUT="$OUT" RUNNER="$(uname -s)" \
+HOME="$CLAUDE_HOME" PROBE=./bin/sandbox-probe OUT="$OUT" RUNNER="$(uname -s)" \
 SCAN_ARGS="scan --tasks baseline_sandbox_task --tasksets none" \
   bash "${PROJECT_ROOT}/scripts/run-probe-via-claude-stub.sh"
 

--- a/tests/detect_docker.sh
+++ b/tests/detect_docker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-mkdir -p $HOME/.sandbox-probe/tmp
-TMPDIR=$(mktemp -d -p $HOME/.sandbox-probe/tmp)
+mkdir -p "$HOME/.sandbox-probe/tmp"
+TMPDIR=$(mktemp -d -p "$HOME/.sandbox-probe/tmp")
 echo "created TMPDIR: $TMPDIR"
 
 # Get the directory of this script
@@ -11,17 +11,20 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 echo "Testing docker"
 
 # Run the probe in Claude sandbox using absolute paths
-"${PROJECT_ROOT}/scripts/run-docker.sh" "bin/sandbox-probe" $TMPDIR
+"${PROJECT_ROOT}/scripts/run-docker.sh" "bin/sandbox-probe" "$TMPDIR"
 
 
 # Display the report
 if [ -f "$TMPDIR/report.json" ]; then
-    echo "\n=== Report Generated ==="
-    jq '.' $TMPDIR/report.json
+    printf '\n=== Report Generated ===\n'
+    jq '.' "$TMPDIR/report.json"
+
+    mkdir -p ./reports
+    cp "$TMPDIR/report.json" ./reports/sandbox-docker.json
 
     # Verify Docker detection - produces boolean
-    echo "\n=== Verifying Docker Detection ==="
-    pass=$(jq 'any(.findings[]; .findingType == "sandbox_detection" and .task == "baseline_sandbox_detector" and .value == "docker")' $TMPDIR/report.json)
+    printf '\n=== Verifying Docker Detection ===\n'
+    pass=$(jq 'any(.findings[]; .findingType == "sandbox_detection" and .task == "baseline_sandbox_detector" and .value == "docker")' "$TMPDIR/report.json")
     if [ "$pass" = "true" ]; then
         echo "Docker detected: ✓ Test passed"
         exit 0
@@ -33,6 +36,3 @@ else
     echo "ERROR: report.json not found"
     exit 1
 fi
-
-mkdir -p ./reports
-cp $TMPDIR/report.json ./reports/sandbox-docker.json

--- a/tests/example/Dockerfile
+++ b/tests/example/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create host operator (bob) and AI agent (alice) users
+RUN groupadd --gid 1000 bob \
+ && useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash bob \
+ && groupadd --gid 1001 alice \
+ && useradd --uid 1001 --gid 1001 --create-home --shell /bin/bash alice
+
+# Credential directories owned by bob (mode 700)
+RUN install -d -m 700 -o bob -g bob \
+      /home/bob/.ssh \
+      /home/bob/.aws \
+      /home/bob/.gnupg \
+      /home/bob/.kube \
+      /home/bob/.config
+
+# Synthetic key files - placeholder content, realistic structure
+RUN echo 'PLACEHOLDER_SSH_KEY' > /home/bob/.ssh/id_rsa \
+ && echo 'PLACEHOLDER_SSH_KEY' > /home/bob/.ssh/id_ed25519 \
+ && chown -R bob:bob /home/bob/.ssh \
+ && chmod 600 /home/bob/.ssh/id_rsa /home/bob/.ssh/id_ed25519
+
+# Synthetic AWS config file
+RUN printf '[default]\nregion = us-east-1\n' > /home/bob/.aws/credentials \
+ && chown bob:bob /home/bob/.aws/credentials \
+ && chmod 600 /home/bob/.aws/credentials
+
+# Synthetic kubeconfig
+RUN printf 'apiVersion: v1\nkind: Config\n' > /home/bob/.kube/config \
+ && chown bob:bob /home/bob/.kube/config \
+ && chmod 600 /home/bob/.kube/config
+
+# Alice workspace
+RUN install -d -m 755 -o alice -g alice /home/alice/workspace
+
+# Copy sandbox-probe binary and probe config
+COPY bin/sandbox-probe /usr/local/bin/sandbox-probe
+RUN chmod 755 /usr/local/bin/sandbox-probe \
+ && mkdir -p /etc/sandbox-probe
+COPY tests/example/alice-sandbox.yaml /etc/sandbox-probe/alice-sandbox.yaml
+
+USER alice
+WORKDIR /home/alice/workspace
+
+CMD ["sandbox-probe", "scan", "--config", "/etc/sandbox-probe/alice-sandbox.yaml"]

--- a/tests/example/alice-sandbox.yaml
+++ b/tests/example/alice-sandbox.yaml
@@ -1,0 +1,117 @@
+# sandbox-probe custom_paths config — alice/bob two-user AI sandbox example
+#
+# Scenario: alice is an AI agent running in a sandboxed environment.
+#           bob is the human operator whose credentials must remain inaccessible.
+#
+# How to use:
+#   sandbox-probe scan \
+#     --config tests/example/alice-sandbox.yaml \
+#     --output_path /tmp/sandbox-probe-report.json
+#
+# Schema:
+#   identity       — who this config is for (informational + used for path inference)
+#   custom_paths   — the boundary declarations
+#     must_block   — paths that MUST be denied (readdir + open). FAIL if readable.
+#     must_read    — paths that MUST be readable (readdir OK). FAIL if denied.
+#     must_readwrite — paths that MUST be fully accessible. FAIL if denied.
+#     audit        — paths to probe and report on with no pass/fail expectation.
+#
+# severity levels: critical (abort on failure), error (fail scan), warn (log only)
+
+identity:
+  sandbox_user: alice       # The AI agent's unix user
+  sandbox_uid: 1001
+  host_user: bob            # The human operator's unix user
+  host_uid: 1000
+
+custom_paths:
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # MUST BLOCK — content MUST be inaccessible (readdir=DENIED, open=DENIED)
+  # stat() returning true is expected and acceptable (VFS path existence leak).
+  # ─────────────────────────────────────────────────────────────────────────
+  must_block:
+
+    # ── Cryptographic secrets & credentials ──────────────────────────────
+    - path: /home/bob/.ssh
+      label: ssh_keys
+      severity: critical
+      reason: "SSH private keys — exposure = full host compromise"
+      check_files:
+        - id_rsa
+        - id_ed25519
+        - authorized_keys
+        - config
+
+    - path: /home/bob/.aws
+      label: aws_credentials
+      severity: critical
+      reason: "AWS credentials — exposure = cloud account compromise"
+      check_files:
+        - credentials
+        - config
+
+    - path: /home/bob/.gnupg
+      label: gpg_keys
+      severity: critical
+      reason: "GPG private keys — exposure = identity and signing key compromise"
+
+    - path: /home/bob/.kube
+      label: kube_config
+      severity: critical
+      reason: "Kubernetes cluster credentials"
+      check_files:
+        - config
+
+    - path: /home/bob/.config
+      label: host_config
+      severity: error
+      reason: "Host user config dir — may contain cloud CLI tokens and secrets"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # MUST READ — paths expected to be readable (system tooling)
+  # ─────────────────────────────────────────────────────────────────────────
+  must_read:
+
+    - path: /usr/local/bin
+      label: usr_local_bin
+      severity: error
+      reason: "User-installed tools must be accessible to the AI agent"
+
+    - path: /usr/bin
+      label: usr_bin
+      severity: error
+      reason: "System binaries — required for shell and utilities"
+
+    - path: /usr/lib
+      label: usr_lib
+      severity: error
+      reason: "Shared libraries — required for dynamic linking"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # MUST READWRITE — the AI agent's active working area
+  # ─────────────────────────────────────────────────────────────────────────
+  must_readwrite:
+
+    - path: /home/alice/workspace
+      label: alice_workspace
+      severity: critical
+      reason: "Primary working directory — AI agent must be able to read and write here"
+
+    - path: /tmp
+      label: tmp
+      severity: error
+      reason: "Temp dir — needed for tool output and intermediate artefacts"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # AUDIT — probe and report, no pass/fail verdict
+  # ─────────────────────────────────────────────────────────────────────────
+  audit:
+
+    - path: /home/bob
+      label: host_home_root
+      note: "Host home root — path existence may be visible via stat, content should be blocked"
+
+    - path: /proc/self
+      label: proc_self
+      note: "Own process info — readable, expected"

--- a/tests/example/alice-sandbox.yaml
+++ b/tests/example/alice-sandbox.yaml
@@ -9,14 +9,20 @@
 #     --output_path /tmp/sandbox-probe-report.json
 #
 # Schema:
-#   identity       — who this config is for (informational + used for path inference)
+#   identity       — who this config is for (informational only)
 #   custom_paths   — the boundary declarations
-#     must_block   — paths that MUST be denied (readdir + open). FAIL if readable.
+#     must_block   — paths whose readdir, open, and write operations MUST be denied.
 #     must_read    — paths that MUST be readable (readdir OK). FAIL if denied.
-#     must_readwrite — paths that MUST be fully accessible. FAIL if denied.
+#     must_readwrite — paths that MUST permit directory reading and writing.
 #     audit        — paths to probe and report on with no pass/fail expectation.
 #
-# severity levels: critical (abort on failure), error (fail scan), warn (log only)
+# severity levels: critical and error fail the completed scan after its report
+# is written; warn records a finding without failing the scan.
+#
+# check_ops replaces a category's default operations for that entry.
+# check_files is available only on must_block and accepts simple file names.
+# stat_may_fail permits an absent must_read or must_readwrite path.
+# Paths must be absolute POSIX, Windows drive, or Windows UNC paths.
 
 identity:
   sandbox_user: alice       # The AI agent's unix user
@@ -27,8 +33,8 @@ identity:
 custom_paths:
 
   # ─────────────────────────────────────────────────────────────────────────
-  # MUST BLOCK — content MUST be inaccessible (readdir=DENIED, open=DENIED)
-  # stat() returning true is expected and acceptable (VFS path existence leak).
+  # MUST BLOCK — readdir, open, and write must be denied.
+  # stat() visibility is recorded but does not violate this expectation.
   # ─────────────────────────────────────────────────────────────────────────
   must_block:
 
@@ -89,7 +95,7 @@ custom_paths:
       reason: "Shared libraries — required for dynamic linking"
 
   # ─────────────────────────────────────────────────────────────────────────
-  # MUST READWRITE — the AI agent's active working area
+  # MUST READWRITE — paths must permit directory reading and writing
   # ─────────────────────────────────────────────────────────────────────────
   must_readwrite:
 

--- a/tests/example/alice-sandbox.yaml
+++ b/tests/example/alice-sandbox.yaml
@@ -34,7 +34,7 @@ custom_paths:
 
   # ─────────────────────────────────────────────────────────────────────────
   # MUST BLOCK — readdir, open, and write must be denied.
-  # stat() visibility is recorded but does not violate this expectation.
+  # stat() visibility is permitted and does not violate this expectation.
   # ─────────────────────────────────────────────────────────────────────────
   must_block:
 

--- a/tests/example/run.sh
+++ b/tests/example/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# tests/example/run.sh
+# Build the sandbox-probe Docker example and run the alice/bob boundary demo.
+#
+# This demonstrates sandbox-probe's reporting capability using two Docker users:
+#   alice — AI agent user (runs sandbox-probe)
+#   bob   — host operator whose credentials are planted but should be blocked
+#
+# NOTE: Docker provides no Landlock/MAC enforcement, so must_block violations
+# WILL appear (alice can read bob's files via standard DAC). This is expected.
+# The example demonstrates the config format and reporting, not enforcement.
+# For real enforcement, run sandbox-probe inside a nono/Landlock sandbox.
+#
+# Usage: bash tests/example/run.sh
+#        make docker-test
+
+set -uo pipefail
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; YELLOW='\033[0;33m'; GREEN='\033[0;32m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+# ── Preflight: binary ─────────────────────────────────────────────────────────
+if [[ ! -f "bin/sandbox-probe" ]]; then
+  echo -e "${RED}${BOLD}ERROR: bin/sandbox-probe not found.${RESET}"
+  echo "  Build it first: make build"
+  exit 1
+fi
+
+# ── Preflight: Docker ─────────────────────────────────────────────────────────
+if ! docker info >/dev/null 2>&1; then
+  echo -e "${RED}${BOLD}ERROR: Docker is not running or not installed.${RESET}"
+  echo "  Start Docker and retry."
+  exit 1
+fi
+
+echo ""
+echo -e "${BOLD}${CYAN}── sandbox-probe Docker Example ──────────────────────────────${RESET}"
+echo -e "${BOLD}${CYAN}   Scenario: alice (AI agent) vs bob (host operator)${RESET}"
+echo ""
+echo "  Building Docker image..."
+docker build -q -t sandbox-probe-example -f tests/example/Dockerfile . \
+  || { echo -e "${RED}Docker build failed${RESET}"; exit 1; }
+echo "  Image built: sandbox-probe-example"
+echo ""
+echo "  Running sandbox-probe as alice inside the container..."
+echo ""
+
+docker run --rm sandbox-probe-example
+PROBE_EXIT=$?
+
+echo ""
+echo -e "${YELLOW}${BOLD}NOTE:${RESET} In Docker without Landlock enforcement, alice can read bob's files"
+echo "  via standard Unix DAC — so must_block violations are expected here."
+echo "  For real enforcement, run sandbox-probe inside a nono/Landlock sandbox."
+echo ""
+
+if [[ "${PROBE_EXIT}" -eq 0 ]]; then
+  echo -e "${GREEN}${BOLD}✅ PASS — sandbox-probe ran successfully (all paths resolved)${RESET}"
+else
+  echo -e "${YELLOW}${BOLD}⚠️  VIOLATIONS REPORTED (expected without Landlock)${RESET}"
+  echo "  Exit code: ${PROBE_EXIT}"
+  echo "  This is correct behaviour — the config file is valid and the tool works."
+fi
+
+echo ""

--- a/tests/example/run.sh
+++ b/tests/example/run.sh
@@ -6,10 +6,9 @@
 #   alice — AI agent user (runs sandbox-probe)
 #   bob   — host operator whose credentials are planted but should be blocked
 #
-# NOTE: Docker provides no Landlock/MAC enforcement, so must_block violations
-# WILL appear (alice can read bob's files via standard DAC). This is expected.
-# The example demonstrates the config format and reporting, not enforcement.
-# For real enforcement, run sandbox-probe inside a nono/Landlock sandbox.
+# NOTE: Docker is not a substitute for Landlock/MAC enforcement. This fixture
+# uses Unix DAC permissions, so the must_block checks should pass; real
+# sandboxing must still be verified with a nono/Landlock policy.
 #
 # Usage: bash tests/example/run.sh
 #        make docker-test
@@ -50,17 +49,16 @@ docker run --rm sandbox-probe-example
 PROBE_EXIT=$?
 
 echo ""
-echo -e "${YELLOW}${BOLD}NOTE:${RESET} In Docker without Landlock enforcement, alice can read bob's files"
-echo "  via standard Unix DAC — so must_block violations are expected here."
-echo "  For real enforcement, run sandbox-probe inside a nono/Landlock sandbox."
+echo -e "${YELLOW}${BOLD}NOTE:${RESET} This Docker fixture demonstrates Unix DAC permissions only."
+echo "  For real sandbox enforcement, run sandbox-probe inside a nono/Landlock sandbox."
 echo ""
 
 if [[ "${PROBE_EXIT}" -eq 0 ]]; then
-  echo -e "${GREEN}${BOLD}✅ PASS — sandbox-probe ran successfully (all paths resolved)${RESET}"
-else
-  echo -e "${YELLOW}${BOLD}⚠️  VIOLATIONS REPORTED (expected without Landlock)${RESET}"
-  echo "  Exit code: ${PROBE_EXIT}"
-  echo "  This is correct behaviour — the config file is valid and the tool works."
+	echo -e "${GREEN}${BOLD}✅ PASS — sandbox-probe verified the fixture boundaries${RESET}"
+	else
+	echo -e "${RED}${BOLD}❌ FAIL — sandbox-probe reported boundary violations${RESET}"
+	echo "  Exit code: ${PROBE_EXIT}"
+	exit "${PROBE_EXIT}"
 fi
 
 echo ""

--- a/tests/nono/relaxed-baseline.json
+++ b/tests/nono/relaxed-baseline.json
@@ -1,0 +1,36 @@
+{
+  "extends": null,
+  "meta": {
+    "name": "sandbox-probe-relaxed-baseline",
+    "version": "1.0.0",
+    "description": "Relaxed Linux and macOS sandbox-probe baseline without granting nono state",
+    "author": "controlplaneio"
+  },
+  "groups": { "include": [], "exclude": [] },
+  "commands": { "allow": [], "deny": [] },
+  "filesystem": {
+    "allow": ["~/.sandbox-probe"],
+    "read": [
+      "/bin", "/dev", "/etc", "/lib", "/lib64", "/proc", "/run", "/sbin", "/sys", "/usr", "/var",
+      "/System", "/Library", "/private", "/Applications",
+      "/root", "~/.aws", "~/.azure", "~/.cargo", "~/.cloudflared", "~/.config/gcloud", "~/.config/gh",
+      "~/.config/doctl", "~/.config/op", "~/.docker", "~/.fly", "~/.gcloud", "~/.gem", "~/.gnupg", "~/.gradle",
+      "~/.kube", "~/.m2", "~/.npmrc", "~/.pypirc", "~/.ssh", "~/.terraform.d",
+      "~/.gitconfig", "~/.git-credentials", "~/.netrc", "~/.vault-token"
+    ],
+    "write": [],
+    "allow_file": [], "read_file": [], "write_file": [],
+    "unix_socket": [], "unix_socket_bind": [], "unix_socket_dir": [], "unix_socket_dir_bind": [],
+    "unix_socket_subtree": [], "unix_socket_subtree_bind": [],
+    "deny": [], "bypass_protection": [], "suppress_save_prompt": []
+  },
+  "network": { "block": false, "allow_domain": [], "open_port": [], "listen_port": [], "connect_port": [], "custom_credentials": {}, "upstream_proxy": null, "upstream_bypass": [] },
+  "linux": { "af_unix_mediation": null },
+  "env_credentials": {},
+  "environment": null,
+  "workdir": { "access": "none" },
+  "hooks": {}, "rollback": { "exclude_patterns": [], "exclude_globs": [] },
+  "open_urls": null, "allow_launch_services": null, "allow_gpu": null,
+  "allow_parent_of_protected": null, "interactive": false, "skipdirs": [], "packs": [],
+  "command_args": [], "unsafe_macos_seatbelt_rules": []
+}

--- a/tests/sandbox_claude.sh
+++ b/tests/sandbox_claude.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-mkdir -p $HOME/.sandbox-probe/tmp
-TMPDIR=$(mktemp -d -p $HOME/.sandbox-probe/tmp)
+mkdir -p "$HOME/.sandbox-probe/tmp"
+TMPDIR=$(mktemp -d -p "$HOME/.sandbox-probe/tmp")
 echo "created TMPDIR: $TMPDIR"
 
 # Get the directory of this script
@@ -11,16 +11,16 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 echo "Testing sandbox mode with Claude"
 
 # Run the probe in Claude sandbox using absolute paths
-"${PROJECT_ROOT}/scripts/run-claude-sandbox.sh" "bin/sandbox-probe" $TMPDIR
+"${PROJECT_ROOT}/scripts/run-claude-sandbox.sh" "bin/sandbox-probe" "$TMPDIR"
 
 # Display the report
 if [ -f "$TMPDIR/report.json" ]; then
-    echo "\n=== Report Generated ==="
-    jq '.' $TMPDIR/report.json
+    printf '\n=== Report Generated ===\n'
+    jq '.' "$TMPDIR/report.json"
 else
     echo "ERROR: report.json not found"
     exit 1
 fi
 
 mkdir -p ./reports
-cp $TMPDIR/report.json ./reports/sandbox-claude.json
+cp "$TMPDIR/report.json" ./reports/sandbox-claude.json

--- a/tests/sandbox_nono.sh
+++ b/tests/sandbox_nono.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 
-mkdir -p $HOME/.sandbox-probe/tmp
-TMPDIR=$(mktemp -d -p $HOME/.sandbox-probe/tmp)
+mkdir -p "$HOME/.sandbox-probe/tmp"
+TMPDIR=$(mktemp -d -p "$HOME/.sandbox-probe/tmp")
 echo "created TMPDIR: $TMPDIR"
 
 echo "Testing sandbox mode (normal usage) with Nono"
 
-cp ./bin/sandbox-probe $TMPDIR
+cp ./bin/sandbox-probe "$TMPDIR"
 OLDDIR="$PWD"
-cd "$TMPDIR"
+cd "$TMPDIR" || exit
 
 # file needs to exist before nono allows access
 touch report.json
@@ -24,14 +24,14 @@ nono run --silent --allow-cwd --allow-file ./report.json ./sandbox-probe scan
 
 # Display the report
 if [ -f "$TMPDIR/report.json" ]; then
-    echo "\n=== Report Generated ==="
-    jq '.' $TMPDIR/report.json
+    printf '\n=== Report Generated ===\n'
+    jq '.' "$TMPDIR/report.json"
 else
     echo "ERROR: report.json not found"
     exit 1
 fi
 
-cd "$OLDDIR"
+cd "$OLDDIR" || exit
 
 mkdir -p ./reports
-cp $TMPDIR/report.json ./reports/sandbox-nono.json
+cp "$TMPDIR/report.json" ./reports/sandbox-nono.json


### PR DESCRIPTION
## Summary

Adds a `--config <yaml>` flag to `sandbox-probe scan` for declarative filesystem boundary checking. Users define expected access rules in a YAML file; the scanner reports violations as structured findings.

## What's new

### `--config <path>` flag (global, persistent)

```bash
sandbox-probe scan --config tests/example/alice-sandbox.yaml --output_path report.json
```

### Config schema (`pkg/config/`)

Four path categories:

- **`must_block`** — readdir + open must be denied (Landlock/DAC enforcement check)
- **`must_read`** — readdir must succeed (system tooling reachable)
- **`must_readwrite`** — readdir + write must succeed (active workspace)
- **`audit`** — all four ops probed, no pass/fail (informational)

Per-entry fields: `path`, `label`, `severity` (critical/error/warn), `reason`, `check_files` (per-file open=denied inside a dir), `check_ops` (override which ops are tested), `stat_may_fail`, `note`.

### Findings

- `custom_path_violation` — a must_* expectation was not met
- `custom_path_audit` — audit-only observation (stat/readdir/open/write state)

Each finding includes path, label, op, severity, expected, got, and message.

## Example config

`tests/example/alice-sandbox.yaml` — a complete boundary spec for an AI agent user, declaring which host paths must be blocked (SSH keys, AWS creds, kubeconfig, host source tree) and which must be accessible (system tooling, `/tmp`, agent workspace).

## Testing

```bash
go test ./...   # 11 new config unit tests + all existing green
sandbox-probe scan --config tests/example/alice-sandbox.yaml --fast
```

Validated end-to-end with nono + Landlock active:
- `must_block` credential paths: readdir + open correctly denied under sandbox
- `/tmp` grant working after explicit path in nono profile patch
- Viper isolation: `--config` YAML parsed only by `config.LoadConfig()`, not fed to viper

## Files changed

| File | Purpose |
|------|---------|
| `pkg/config/config.go` | Schema + `LoadConfig()` with validation |
| `pkg/config/config_test.go` | 11 unit tests incl. real `alice-sandbox.yaml` |
| `pkg/tasks/baseline/custom_paths.go` | `CheckCustomPaths()` runner |
| `pkg/tasks/custom_paths_task.go` | `Task` interface wrapper |
| `cmd/cmd.go` | `--config` persistent flag; viper isolation fix |
| `cmd/scan.go` | Config load + task append |
| `tests/example/` | Boundary spec, test harness, example Dockerfile |

## Windows support

Removed the Windows early-return stub from `scanTargetedPathsForHome()`. Sensitive paths and system write paths are now split into platform functions (`filesystem_unix.go` / `filesystem_windows.go`), so the scanner runs real credential detection on all three platforms.