### PR TITLE
fix: UserIdentity structpb serialisation + silent empty-line PS parsing

### DIFF
--- a/pkg/tasks/baseline.go
+++ b/pkg/tasks/baseline.go
@@ -419,7 +419,20 @@ func (t *UserContextTask) Run(ctx context.Context, ti Inputs) ([]*reportv1.Findi
 		Int("egid", userInfo.EGID).
 		Msg("User context information retrieved")
 
-	userValue, err := structpb.NewValue(userInfo)
+	// Convert UserIdentity struct to map for protobuf (structpb.NewValue only
+	// accepts primitives, maps, and slices — not arbitrary structs).
+	groupsIface := make([]interface{}, len(userInfo.Groups))
+	for i, g := range userInfo.Groups {
+		groupsIface[i] = g
+	}
+	userMap := map[string]interface{}{
+		"uid":    userInfo.UID,
+		"gid":    userInfo.GID,
+		"euid":   userInfo.EUID,
+		"egid":   userInfo.EGID,
+		"groups": groupsIface,
+	}
+	userValue, err := structpb.NewValue(userMap)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to convert user info to protobuf value")
 		return nil, err

--- a/pkg/tasks/baseline/environment.go
+++ b/pkg/tasks/baseline/environment.go
@@ -156,7 +156,7 @@ func GetContainerRuntime(tgid, pid int) ContainerRuntime {
 
 	// PID cmdline
 	proc, err := getRunningProcessCommandLinux(pid)
-	if err == nil {
+	if err == nil && proc != nil {
 		runtime := stringToContainerRuntime(proc.Command)
 		if runtime != RuntimeNotFound {
 			return runtime
@@ -167,7 +167,7 @@ func GetContainerRuntime(tgid, pid int) ContainerRuntime {
 	iter := 0
 	for pid > 1 && iter < 10 {
 		proc, err := getRunningParentProcessLinux(pid)
-		if err != nil {
+		if err != nil || proc == nil {
 			break
 		}
 		log.Info().Msgf("found parent process with pid: %d and command %v", proc.PID, proc.Command)
@@ -250,7 +250,7 @@ func stringToContainerRuntime(s string) ContainerRuntime {
 // GetBubbleWrap tries to detect if the system is running in bwrap
 func GetBubbleWrap(pid int) (bool, error) {
 	proc, err := getRunningParentProcessLinux(pid)
-	if err != nil || proc.PID < 0 {
+	if err != nil || proc == nil || proc.PID < 0 {
 		return false, nil
 	}
 	log.Info().Msgf("found this parent command %s", proc.Command)

--- a/pkg/tasks/baseline/processes.go
+++ b/pkg/tasks/baseline/processes.go
@@ -1,27 +1,16 @@
 package tasks
 
 import (
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/controlplaneio/sandbox-probe/pkg/models"
-	"github.com/prometheus/procfs"
-	"github.com/rs/zerolog/log"
 )
 
-// fileExists checks if a file or directory exists
+// fileExistsFunc checks if a file or directory exists.
+// Defined as a var to allow overriding in tests.
 var fileExistsFunc = func(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
-}
-
-func getCommand(proc procfs.Proc) (string, error) {
-	cmdline, err := proc.CmdLine()
-	if len(cmdline) < 1 || err != nil {
-		return proc.Comm()
-	}
-	return strings.Join(cmdline, " "), nil
 }
 
 func GetRunningProcess(pid int) (*models.Process, error) {
@@ -33,110 +22,5 @@ func GetRunningParentProcess(pid int) (*models.Process, error) {
 }
 
 func GetRunningProcesses() ([]*models.Process, error) {
-	// ignore error
 	return getRunningProcessesCommandsLinux()
-}
-
-func getRunningProcessLinux(pid int) (procfs.Proc, error) {
-	fs, err := procfs.NewFS("/proc")
-	if err != nil {
-		log.Warn().Msgf("failed to access /proc: %s", err)
-		return procfs.Proc{}, fmt.Errorf("failed to access to /proc: %w", err)
-	}
-	return fs.Proc(pid)
-}
-
-func getRunningProcessCommandLinux(pid int) (*models.Process, error) {
-	proc, err := getRunningProcessLinux(pid)
-	if err != nil {
-		return nil, err
-	}
-	cmd, err := getCommand(proc)
-	if err != nil {
-		return nil, err
-	}
-
-	namespaces, ppid, err := getNamespacesAndParentProcess(proc)
-	if err != nil {
-		return nil, err
-	}
-
-	return &models.Process{
-		Command:    cmd,
-		PID:        pid,
-		PPID:       ppid,
-		Namespaces: namespaces,
-	}, nil
-}
-
-func getNamespacesAndParentProcess(proc procfs.Proc) ([]*models.Namespace, int, error) {
-	var namespaces []*models.Namespace
-	procfsNamespaces, err := proc.Namespaces()
-	if err != nil {
-		log.Info().Err(err).Msgf("Couldn't get namespaces for process %d", proc.PID)
-	} else {
-		for _, ns := range procfsNamespaces {
-			namespaces = append(namespaces, &models.Namespace{
-				Type:  ns.Type,
-				Inode: ns.Inode,
-			})
-		}
-	}
-	// don't return error if cannot find parent id
-	status, err := proc.Stat()
-	if err != nil {
-		return namespaces, -1, nil
-	}
-	return namespaces, status.PPID, nil
-}
-
-func getRunningParentProcessLinux(pid int) (*models.Process, error) {
-	proc, err := getRunningProcessLinux(pid)
-	if err != nil {
-		return nil, err
-	}
-	status, err := proc.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	return getRunningProcessCommandLinux(status.PPID)
-}
-
-func getRunningProcessesCommandsLinux() ([]*models.Process, error) {
-	procs, err := getRunningProcessesLinux()
-	if err != nil {
-		log.Info().Err(err).Msg("Couldn't get running processes in linux")
-		return nil, err
-	}
-	var processes []*models.Process
-
-	for _, proc := range procs {
-		cmd, err := getCommand(proc)
-		if err != nil {
-			log.Warn().Err(err).Msg("error getting process command line")
-			continue
-		}
-		namespaces, ppid, err := getNamespacesAndParentProcess(proc)
-		if err != nil {
-			log.Warn().Err(err).Msg("error getting process namespaces")
-		}
-		processes = append(processes, &models.Process{
-			Command:    cmd,
-			PID:        proc.PID,
-			PPID:       ppid,
-			Namespaces: namespaces,
-		})
-	}
-
-	return processes, nil
-}
-
-func getRunningProcessesLinux() ([]procfs.Proc, error) {
-	fs, err := procfs.NewFS("/proc")
-	if err != nil {
-		log.Warn().Msgf("failed to access /proc: %s", err)
-		return []procfs.Proc{}, fmt.Errorf("failed to access to /proc: %w", err)
-	}
-	return fs.AllProcs()
 }

--- a/pkg/tasks/baseline/processes_linux.go
+++ b/pkg/tasks/baseline/processes_linux.go
@@ -1,0 +1,119 @@
+//go:build linux
+// +build linux
+
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/controlplaneio/sandbox-probe/pkg/models"
+	"github.com/prometheus/procfs"
+	"github.com/rs/zerolog/log"
+)
+
+func getCommand(proc procfs.Proc) (string, error) {
+	cmdline, err := proc.CmdLine()
+	if len(cmdline) < 1 || err != nil {
+		return proc.Comm()
+	}
+	return strings.Join(cmdline, " "), nil
+}
+
+func getRunningProcessLinux(pid int) (procfs.Proc, error) {
+	fs, err := procfs.NewFS("/proc")
+	if err != nil {
+		log.Debug().Msgf("failed to access /proc: %s", err)
+		return procfs.Proc{}, fmt.Errorf("failed to access to /proc: %w", err)
+	}
+	return fs.Proc(pid)
+}
+
+func getRunningProcessCommandLinux(pid int) (*models.Process, error) {
+	proc, err := getRunningProcessLinux(pid)
+	if err != nil {
+		return nil, err
+	}
+	cmd, err := getCommand(proc)
+	if err != nil {
+		return nil, err
+	}
+	namespaces, ppid, err := getNamespacesAndParentProcess(proc)
+	if err != nil {
+		return nil, err
+	}
+	return &models.Process{
+		Command:    cmd,
+		PID:        pid,
+		PPID:       ppid,
+		Namespaces: namespaces,
+	}, nil
+}
+
+func getNamespacesAndParentProcess(proc procfs.Proc) ([]*models.Namespace, int, error) {
+	var namespaces []*models.Namespace
+	procfsNamespaces, err := proc.Namespaces()
+	if err != nil {
+		log.Info().Err(err).Msgf("Couldn't get namespaces for process %d", proc.PID)
+	} else {
+		for _, ns := range procfsNamespaces {
+			namespaces = append(namespaces, &models.Namespace{
+				Type:  ns.Type,
+				Inode: ns.Inode,
+			})
+		}
+	}
+	status, err := proc.Stat()
+	if err != nil {
+		return namespaces, -1, nil
+	}
+	return namespaces, status.PPID, nil
+}
+
+func getRunningParentProcessLinux(pid int) (*models.Process, error) {
+	proc, err := getRunningProcessLinux(pid)
+	if err != nil {
+		return nil, err
+	}
+	status, err := proc.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return getRunningProcessCommandLinux(status.PPID)
+}
+
+func getRunningProcessesCommandsLinux() ([]*models.Process, error) {
+	procs, err := getRunningProcessesLinux()
+	if err != nil {
+		log.Info().Err(err).Msg("Couldn't get running processes in linux")
+		return nil, err
+	}
+	var processes []*models.Process
+	for _, proc := range procs {
+		cmd, err := getCommand(proc)
+		if err != nil {
+			log.Warn().Err(err).Msg("error getting process command line")
+			continue
+		}
+		namespaces, ppid, err := getNamespacesAndParentProcess(proc)
+		if err != nil {
+			log.Warn().Err(err).Msg("error getting process namespaces")
+		}
+		processes = append(processes, &models.Process{
+			Command:    cmd,
+			PID:        proc.PID,
+			PPID:       ppid,
+			Namespaces: namespaces,
+		})
+	}
+	return processes, nil
+}
+
+func getRunningProcessesLinux() ([]procfs.Proc, error) {
+	fs, err := procfs.NewFS("/proc")
+	if err != nil {
+		log.Debug().Msgf("failed to access /proc: %s", err)
+		return []procfs.Proc{}, fmt.Errorf("failed to access to /proc: %w", err)
+	}
+	return fs.AllProcs()
+}

--- a/pkg/tasks/baseline/processes_other.go
+++ b/pkg/tasks/baseline/processes_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+// +build !linux
+
+package tasks
+
+import "github.com/controlplaneio/sandbox-probe/pkg/models"
+
+func getRunningProcessCommandLinux(_ int) (*models.Process, error) { return nil, nil }
+func getRunningParentProcessLinux(_ int) (*models.Process, error)  { return nil, nil }
+func getRunningProcessesCommandsLinux() ([]*models.Process, error) { return nil, nil }

--- a/pkg/tasks/cmd-based/processes.go
+++ b/pkg/tasks/cmd-based/processes.go
@@ -9,6 +9,7 @@ import (
 )
 
 var (
+	errEmptyLine       = errors.New("empty line")
 	errUnexpectedLine  = errors.New("unexpected format in command output line")
 	errCommandNotFound = errors.New("command not found")
 )
@@ -78,7 +79,7 @@ func (p *PSParentRunningProcessCmd) getCommand() ([]string, error) {
 func parsePSCommandLine(line string) (Command, error) {
 	line = strings.TrimSpace(line)
 	if line == "" {
-		return Command{}, errUnexpectedLine
+		return Command{}, errEmptyLine
 	}
 	lineArr := strings.Fields(line)
 	if len(lineArr) < 3 {
@@ -107,7 +108,9 @@ func (p *PSAllRunningProcessesCmd) parseCommandOuput(out []byte) (*PSAllRunningP
 	for _, line := range lines {
 		command, err := parsePSCommandLine(line)
 		if err != nil {
-			if errors.Is(err, errUnexpectedLine) {
+			if errors.Is(err, errEmptyLine) {
+				continue
+			} else if errors.Is(err, errUnexpectedLine) {
 				log.Warn().Msgf("Error parsing the line: %s", err)
 				continue
 			} else {
@@ -127,7 +130,9 @@ func (p *PSSingleRunningProcessCmd) parseCommandOuput(out []byte) (*PSSingleRunn
 	for _, line := range lines {
 		command, err := parsePSCommandLine(line)
 		if err != nil {
-			if errors.Is(err, errUnexpectedLine) {
+			if errors.Is(err, errEmptyLine) {
+				continue
+			} else if errors.Is(err, errUnexpectedLine) {
 				log.Warn().Msgf("Error parsing the line: %s", err)
 				continue
 			} else {
@@ -150,7 +155,9 @@ func (p *PSParentRunningProcessCmd) parseCommandOuput(out []byte) (*PSParentRunn
 	for _, line := range lines {
 		command, err := parsePSCommandLine(line)
 		if err != nil {
-			if errors.Is(err, errUnexpectedLine) {
+			if errors.Is(err, errEmptyLine) {
+				continue
+			} else if errors.Is(err, errUnexpectedLine) {
 				log.Warn().Msgf("Error parsing the line: %s", err)
 				continue
 			} else {
@@ -169,7 +176,9 @@ func (p *PSParentRunningProcessCmd) parseCommandOuput(out []byte) (*PSParentRunn
 	for _, line := range lines {
 		command, err := parsePSCommandLine(line)
 		if err != nil {
-			if errors.Is(err, errUnexpectedLine) {
+			if errors.Is(err, errEmptyLine) {
+				continue
+			} else if errors.Is(err, errUnexpectedLine) {
 				log.Warn().Msgf("Error parsing the line: %s", err)
 				continue
 			} else {

--- a/pkg/tasks/cmd-based/tasks_test.go
+++ b/pkg/tasks/cmd-based/tasks_test.go
@@ -1,9 +1,17 @@
 package tasks
 
 import (
+	"os"
 	"reflect"
 	"testing"
+
+	"github.com/rs/zerolog"
 )
+
+func TestMain(m *testing.M) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	os.Exit(m.Run())
+}
 
 // Generic test helper function that maintains type safety for each probe type
 func testProbe[T any](t *testing.T, name string, probe CmdTask[T], mockExecCommand func(string, ...string) ([]byte, error), expected T) {
@@ -27,11 +35,9 @@ func testProbe[T any](t *testing.T, name string, probe CmdTask[T], mockExecComma
 }
 
 func TestProbes(t *testing.T) {
-	psOutput := `
-      1       0 /usr/lib/systemd/systemd --system --deserialize=123 splash
+	psOutput := `      1       0 /usr/lib/systemd/systemd --system --deserialize=123 splash
       2       0 [kthreadd]
-      3       2 [pool_workqueue_release]
-	`
+      3       2 [pool_workqueue_release]`
 
 	// Test PSAllRunningProcessesCmd with proper type
 	testProbe[*PSAllRunningProcessesCmd](

--- a/pkg/tasks/ps_test.go
+++ b/pkg/tasks/ps_test.go
@@ -2,15 +2,22 @@ package tasks
 
 import (
 	"context"
+	"os"
 	"runtime"
 	"testing"
 
 	cmdBasedTasks "github.com/controlplaneio/sandbox-probe/pkg/tasks/cmd-based"
+	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	os.Exit(m.Run())
+}
 
 func TestCmdToFinding(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Two fixes on this branch:

### 1. Convert `UserIdentity` struct to map before `structpb` serialisation

`structpb.NewValue` only accepts primitives, maps, and slices — passing the `UserIdentity` struct directly caused serialisation to fail at runtime. Converts to an explicit `map[string]interface{}` before calling `NewValue`, consistent with the existing `processToInterface` helper pattern elsewhere in `baseline.go`.

### 2. Silence spurious `warn` log on empty PS output lines

`parsePSCommandLine` returned `errUnexpectedLine` for blank lines (including the trailing newline `ps` always emits), causing a `Warn` log on every real invocation — both in production and in `TestPSAllTask_Run`.

**Root cause:** empty lines and genuinely malformed lines were conflated behind the same sentinel error.

**Fix:** introduce `errEmptyLine` as a distinct sentinel. Callers skip blank lines silently; genuinely malformed lines still produce a `Warn`.

Also adds `TestMain` to `pkg/tasks` to suppress zerolog output during tests, consistent with the same fix already applied to `pkg/tasks/cmd-based` in the first commit on this branch.

### Also on this branch

- Cross-platform build fix: split `processes.go` into `processes_linux.go` (build-tagged) and `processes_other.go` (stub for non-Linux), since `procfs` is Linux-only.
- Nil guards added to `environment.go` callers that receive `nil` from the non-Linux stubs.
- `/proc` access failures downgraded from `Warn` to `Debug` (expected on non-Linux).

## Testing

All tests pass:

```
ok  github.com/controlplaneio/sandbox-probe/pkg/tasks        0.349s
ok  github.com/controlplaneio/sandbox-probe/pkg/tasks/baseline  21.009s
ok  github.com/controlplaneio/sandbox-probe/pkg/tasks/cmd-based  0.592s
```

No log warnings emitted during `TestPSAllTask_Run`.