### PR TITLE
fix(release): build darwin on a real macOS runner, automate the trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,60 @@
 ---
 name: Release
 on:
-  # https://github.com/actions/runner/issues/1007
   push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
 
 jobs:
-  release:
-    name: Release on GitHub
+  version:
+    name: Generate version
     runs-on: ubuntu-latest
+    outputs:
+      semver: ${{ steps.version.outputs.semantic_version }}
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Generate version
+        id: version
+        uses: lukaszraczylo/semver-generator@7b6c46dcb80756cb12e60995207ccd13ca6d70ca # v1
+        with:
+          config_file: semver.yaml
+          repository_local: true
+          strict: true
+
+  release:
+    name: Release on GitHub
+    needs: version
+    # darwin/arm64 builds natively and darwin/amd64 cross-compiles via
+    # Xcode's clang here; linux targets cross-compile fine too since nothing
+    # in the linux build path uses cgo. A Linux runner cannot produce a
+    # working darwin build at all (no Apple SDK/frameworks), which is why
+    # both prior release attempts failed at darwin_amd64_v1.
+    runs-on: macos-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+
+      - name: Tag release
+        run: |
+          git tag "v${{ needs.version.outputs.semver }}"
+          git push origin "v${{ needs.version.outputs.semver }}"
 
       - name: Launch goreleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,11 @@ before:
 builds:
   - main: "."
     binary: sandbox-probe
+    # darwin needs cgo (seatbelt_darwin.go wraps Apple's private sandbox_check
+    # API); linux has no cgo files and no cross C toolchain on the macOS
+    # runner, so it must stay disabled there.
+    env:
+      - CGO_ENABLED={{ if eq .Os "darwin" }}1{{ else }}0{{ end }}
     goos:
       - darwin
       - linux

--- a/semver.yaml
+++ b/semver.yaml
@@ -1,0 +1,22 @@
+version: 1
+force:
+  major: 0
+  minor: 1
+  patch: 0
+wording:
+  patch:
+    - fix
+    - update
+    - pin
+    - relax
+    - revert
+  minor:
+    - add
+    - implement
+    - include
+    - change
+    - improve
+    - feature
+  major:
+    - breaking
+    - major


### PR DESCRIPTION
## Summary
- Both prior release attempts (`v1.0.0`, `v1.1.0`) failed identically at `darwin_amd64_v1` with `undefined: isSeatbelt` — cross-compiling `seatbelt_darwin.go`'s cgo (wraps Apple's private `sandbox_check` API) from a Linux runner is fundamentally impossible, no Apple SDK/frameworks available there. Moves the release job to `macos-latest`, where `darwin/arm64` builds natively and `darwin/amd64` cross-compiles via Xcode's clang.
- Adds a templated per-build `CGO_ENABLED` to `.goreleaser.yml` (`1` for darwin, `0` for linux) — goreleaser does not inherit `CGO_ENABLED` from the ambient environment for cross targets, so `runs-on: macos-latest` alone still reproduces the identical failure; a blanket `CGO_ENABLED=1` instead breaks the linux cross-builds (no linux C toolchain on the runner).
- Switches the trigger from manually-pushed tags (nobody has ever successfully tagged a working release) to push-to-`main`, computing the version via `lukaszraczylo/semver-generator`, tagging, then invoking goreleaser — same pattern as `chrisns/MacWhisperAuto`. `semver.yaml` copied verbatim from that repo for consistency across repos.

Verified locally with real `goreleaser build --snapshot` / `goreleaser release --snapshot` on real Apple Silicon hardware: reproduced the original CI failure with the unmodified config, then reproduced full success (all 6 target archives + checksums) after the fix. Not verified against the real GitHub Actions environment itself — recommend confirming with one real push-to-main after merge.

https://claude.ai/code/session_01Tf69i1pWJwkRz5fYXse35f