### PR TITLE
fix(release): ship windows binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm
@@ -24,6 +25,8 @@ builds:
       - "7"
     ignore:
       - goos: darwin
+        goarch: arm
+      - goos: windows
         goarch: arm
     ldflags:
       - -s -w
@@ -36,6 +39,9 @@ checksum:
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    format_overrides:
+      - goos: windows
+        formats: ["zip"]
 
 snapshot:
   name_template: "{{ .Tag }}-next"


### PR DESCRIPTION
## Summary
- `.goreleaser.yml`'s `goos` list only ever had `darwin`/`linux` — windows was never in the release matrix, despite `scan-matrix.yaml`'s own CI already building and testing a windows binary (`windows-latest`, `.exe`). Nothing windows-specific needs cgo (only `seatbelt_darwin.go` does), so this is a plain addition: `windows/amd64` + `windows/arm64` (windows/arm ignored, same treatment darwin/arm already gets — not a target `scan-matrix.yaml` tests either).
- Adds a `zip` format override for windows archives (everything else stays `tar.gz`, unchanged).

Verified with a real `goreleaser release --snapshot --clean`: all 8 targets build, windows archives are genuine zips containing a real PE32+ binary (confirmed via `file`).

https://claude.ai/code/session_01Tf69i1pWJwkRz5fYXse35f