### PR TITLE
docs(release): document Homebrew install via the shared tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   version:
@@ -64,3 +63,6 @@ jobs:
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pushes the Homebrew formula to the shared controlplaneio/homebrew-tap.
+          # GITHUB_TOKEN can't write to a different repo, hence the separate PAT.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,3 @@ jobs:
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Pushes the Homebrew formula to the shared controlplaneio/homebrew-tap.
-          # GITHUB_TOKEN can't write to a different repo, hence the separate PAT.
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,3 +45,31 @@ archives:
 
 snapshot:
   name_template: "{{ .Tag }}-next"
+
+# Publishes a Homebrew formula on every tagged release, covering macOS and
+# Linux (WSL runs Linux binaries, so no separate WSL formula is needed).
+# main is protected (required review + signed commits), so this opens a PR
+# instead of pushing straight to main; someone still has to merge it.
+brews:
+  - name: sandbox-probe
+    repository:
+      owner: controlplaneio
+      name: sandbox-probe
+      branch: "homebrew-formula-{{ .Version }}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+    directory: Formula
+    # Avoids the patch/minor/major keywords in semver.yaml (e.g. the default
+    # template's "update"), so merging this PR does not trigger another
+    # release via the semver-generator step in release.yml.
+    commit_msg_template: "Homebrew formula for {{ .ProjectName }} {{ .Tag }}"
+    homepage: "https://github.com/controlplaneio/sandbox-probe"
+    description: "Measure what an AI coding agent's sandbox actually allows, instead of trusting its policy on faith."
+    license: "Apache-2.0"
+    commit_author:
+      name: goreleaser-bot
+      email: goreleaser-bot@controlplane.io
+    test: |
+      system "#{bin}/sandbox-probe", "version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,22 +48,15 @@ snapshot:
 
 # Publishes a Homebrew formula on every tagged release, covering macOS and
 # Linux (WSL runs Linux binaries, so no separate WSL formula is needed).
-# main is protected (required review + signed commits), so this opens a PR
-# instead of pushing straight to main; someone still has to merge it.
+# Pushes straight to the shared org tap (no protection there, unlike main
+# here), so this is one release step, not a PR someone has to merge.
 brews:
   - name: sandbox-probe
     repository:
       owner: controlplaneio
-      name: sandbox-probe
-      branch: "homebrew-formula-{{ .Version }}"
-      pull_request:
-        enabled: true
-        base:
-          branch: main
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
-    # Avoids the patch/minor/major keywords in semver.yaml (e.g. the default
-    # template's "update"), so merging this PR does not trigger another
-    # release via the semver-generator step in release.yml.
     commit_msg_template: "Homebrew formula for {{ .ProjectName }} {{ .Tag }}"
     homepage: "https://github.com/controlplaneio/sandbox-probe"
     description: "Measure what an AI coding agent's sandbox actually allows, instead of trusting its policy on faith."

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,23 +46,7 @@ archives:
 snapshot:
   name_template: "{{ .Tag }}-next"
 
-# Publishes a Homebrew formula on every tagged release, covering macOS and
-# Linux (WSL runs Linux binaries, so no separate WSL formula is needed).
-# Pushes straight to the shared org tap (no protection there, unlike main
-# here), so this is one release step, not a PR someone has to merge.
-brews:
-  - name: sandbox-probe
-    repository:
-      owner: controlplaneio
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
-    commit_msg_template: "Homebrew formula for {{ .ProjectName }} {{ .Tag }}"
-    homepage: "https://github.com/controlplaneio/sandbox-probe"
-    description: "Measure what an AI coding agent's sandbox actually allows, instead of trusting its policy on faith."
-    license: "Apache-2.0"
-    commit_author:
-      name: goreleaser-bot
-      email: goreleaser-bot@controlplane.io
-    test: |
-      system "#{bin}/sandbox-probe", "version"
+# No Homebrew-specific config here. controlplaneio/homebrew-tap polls
+# GitHub releases on a schedule and builds its own formula from the
+# archives and checksums.txt this project already publishes above —
+# see controlplaneio-fluxcd/homebrew-tap for the pattern this follows.

--- a/README.md
+++ b/README.md
@@ -413,12 +413,12 @@ For end-to-end testing (depending on which sandboxes you want to exercise):
 
 ### Install with Homebrew (macOS and Linux, including WSL)
 
-Every tagged release opens a pull request with an updated formula. Once
-that pull request is merged, install with:
+Every tagged release publishes an updated formula straight away, no extra
+step needed:
 
 ```bash
-brew tap controlplaneio/sandbox-probe https://github.com/controlplaneio/sandbox-probe
-brew install sandbox-probe
+brew tap controlplaneio/tap
+brew install controlplaneio/tap/sandbox-probe
 ```
 
 This covers macOS (Intel and Apple Silicon) and Linux (`amd64`, `arm64`,
@@ -426,8 +426,8 @@ This covers macOS (Intel and Apple Silicon) and Linux (`amd64`, `arm64`,
 WSL runs a real Linux kernel, so the Linux formula works there too — install
 Homebrew inside your WSL distribution first if you have not already.
 
-Run `brew upgrade sandbox-probe` after future releases to pick up the merged
-formula update.
+Run `brew upgrade sandbox-probe` after future releases to pick up the latest
+formula.
 
 ### Install a released binary
 

--- a/README.md
+++ b/README.md
@@ -413,9 +413,6 @@ For end-to-end testing (depending on which sandboxes you want to exercise):
 
 ### Install with Homebrew (macOS and Linux, including WSL)
 
-Every tagged release publishes an updated formula straight away, no extra
-step needed:
-
 ```bash
 brew tap controlplaneio/tap
 brew install controlplaneio/tap/sandbox-probe
@@ -426,8 +423,10 @@ This covers macOS (Intel and Apple Silicon) and Linux (`amd64`, `arm64`,
 WSL runs a real Linux kernel, so the Linux formula works there too — install
 Homebrew inside your WSL distribution first if you have not already.
 
-Run `brew upgrade sandbox-probe` after future releases to pick up the latest
-formula.
+The `controlplaneio/homebrew-tap` repository checks for new `sandbox-probe`
+releases on a schedule and updates the formula from the archives and
+checksums this project publishes. Run `brew upgrade sandbox-probe` after a
+new release to pick up the update once it lands.
 
 ### Install a released binary
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,24 @@ For end-to-end testing (depending on which sandboxes you want to exercise):
 - `gemini-cli` — Gemini CLI for Gemini testing
 - [`nono`](https://github.com/always-further/nono) — a Landlock/Seatbelt wrapper for AI agents and other programs
 
+### Install with Homebrew (macOS and Linux, including WSL)
+
+Every tagged release opens a pull request with an updated formula. Once
+that pull request is merged, install with:
+
+```bash
+brew tap controlplaneio/sandbox-probe https://github.com/controlplaneio/sandbox-probe
+brew install sandbox-probe
+```
+
+This covers macOS (Intel and Apple Silicon) and Linux (`amd64`, `arm64`,
+`armv6`, `armv7`) through [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux).
+WSL runs a real Linux kernel, so the Linux formula works there too — install
+Homebrew inside your WSL distribution first if you have not already.
+
+Run `brew upgrade sandbox-probe` after future releases to pick up the merged
+formula update.
+
 ### Install a released binary
 
 GitHub releases provide archives for:


### PR DESCRIPTION
## Summary
- Document how to install `sandbox-probe` with Homebrew on macOS and Linux (including WSL) in the README: `brew tap controlplaneio/tap` then `brew install controlplaneio/tap/sandbox-probe`.
- No GoReleaser or workflow change is needed in this repo. `controlplaneio/homebrew-tap` polls GitHub releases on a schedule and builds its own formula from the archives and `checksums.txt` this project already publishes, following the same pattern as [controlplaneio-fluxcd/homebrew-tap](https://github.com/controlplaneio-fluxcd/homebrew-tap/blob/main/.github/workflows/release.yml). No PAT, no branch-protection exception, nothing added to this repo's release pipeline.

An earlier version of this PR had this repo push a formula directly into the tap with a PAT. Per [this review comment](https://github.com/controlplaneio/sandbox-probe/pull/51#issuecomment-5355702122), switched to the polling approach instead, matching what's already used for Flux CD.

https://claude.ai/code/session_01DQC6xmArRj7SgJGWiTHCG8
