### PR TITLE
Point the docs at the comparison repository's real home

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,7 +6,7 @@ reports it emits.
 The comparison-side vocabulary (harness, baseline vs sandbox, identity,
 fingerprint, cell states, capability category, exposure, flip) lives with the
 comparison layer, in
-[`sandbox-probe-reports`](https://github.com/chrisns/sandbox-probe-reports)'s
+[`sandbox-probe-reports`](https://github.com/controlplaneio/sandbox-probe-reports)'s
 `CONTEXT.md`. That is the authoritative definition of those terms; this file
 must not fork them.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `sandbox-probe` is a single static Go binary you drop *inside* the sandbox — [Claude Code](https://code.claude.com/docs/en/overview), [Gemini CLI](https://geminicli.com/), [`nono`](https://github.com/nolabs-ai/nono), a container, whatever — and let it look around. It records what the kernel let it do and writes one JSON report. If that report shows it could read `~/.aws/credentials`, resolve arbitrary DNS, or reach `169.254.169.254`, tighten the policy before you ship another line of code through it.
 
-This repository is the probe and nothing else. The comparison harness built on top of it — the scan matrix, the seeder, the agent stubs, the baseline-normalised methodology and the published results — lives in [`sandbox-probe-reports`](https://github.com/chrisns/sandbox-probe-reports), and its site publishes at <https://chrisns.github.io/sandbox-probe-reports/>. (It was previously published from this repository; that is the new address.)
+This repository is the probe and nothing else. The comparison harness built on top of it — the scan matrix, the seeder, the agent stubs, the baseline-normalised methodology and the published results — lives in [`sandbox-probe-reports`](https://github.com/controlplaneio/sandbox-probe-reports), and its site publishes at <https://controlplaneio.github.io/sandbox-probe-reports/>. (It was previously published from this repository; that is the new address.)
 
 ## Table of contents
 
@@ -26,7 +26,7 @@ Four concrete scenarios `sandbox-probe` is built to answer:
 - **Assessing an AI coding agent's blast radius.** You let developers use Claude Code, Gemini CLI, or similar; you want a concrete inventory of what a compromised agent could read, write, or reach from inside its sandbox.
 - **Tuning a sandbox policy.** You're writing Landlock rules (via [`nono`](https://github.com/nolabs-ai/nono)), a seccomp profile, or a container policy and need before-and-after evidence that the rule you added actually closed the door you intended.
 - **Detecting sandbox regressions over time.** Run the probe in your agent's sandbox on every release of the agent (or your wrapper) and alert when the boundary widens — for example, a new agent version starts seeing `~/.aws/credentials`.
-- **Comparing sandboxes apples-to-apples.** The same probe, run under different sandboxes, produces directly comparable reports. Turning many such reports into a matrix is what [`sandbox-probe-reports`](https://github.com/chrisns/sandbox-probe-reports) does.
+- **Comparing sandboxes apples-to-apples.** The same probe, run under different sandboxes, produces directly comparable reports. Turning many such reports into a matrix is what [`sandbox-probe-reports`](https://github.com/controlplaneio/sandbox-probe-reports) does.
 
 ## How it works
 
@@ -470,6 +470,6 @@ tests/fingerprint/
 
 No agent CLI, model access or API key is involved — a Go toolchain plus the runtimes you want to test is the whole requirement.
 
-Checks that drive a real agent CLI, and everything that compares one sandbox against another, live in [`sandbox-probe-reports`](https://github.com/chrisns/sandbox-probe-reports).
+Checks that drive a real agent CLI, and everything that compares one sandbox against another, live in [`sandbox-probe-reports`](https://github.com/controlplaneio/sandbox-probe-reports).
 
 See [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md) for the full contributor guide, and [`CONTEXT.md`](./CONTEXT.md) for the vocabulary.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -56,9 +56,9 @@ There are two repositories that work as a pair:
 - **[controlplaneio/sandbox-probe](https://github.com/controlplaneio/sandbox-probe)** — this repo: the probe binary,
   its target registry, its Go tests, and the fingerprint checks under `tests/fingerprint/` with the minimal runtime
   launchers under `scripts/` that they invoke.
-- **[sandbox-probe-reports](https://github.com/chrisns/sandbox-probe-reports)** — the comparison harness: the scan
+- **[sandbox-probe-reports](https://github.com/controlplaneio/sandbox-probe-reports)** — the comparison harness: the scan
   matrix, the seeder, the agent stubs, the baseline-normalised methodology, and the reporting site that publishes at
-  <https://chrisns.github.io/sandbox-probe-reports/>. It depends on this repo through a pinned `go.mod` requirement,
+  <https://controlplaneio.github.io/sandbox-probe-reports/>. It depends on this repo through a pinned `go.mod` requirement,
   and reads the probe through exactly two things: `list-targets` and the report JSON.
 
 If you're adding a probe task, a sandbox detector, or a registry target, that work lives here. If you're changing how
@@ -245,7 +245,7 @@ privileged container when the host cannot run `runsc` directly.
 ##### Known Working Tooling Versions
 
 Checks that drive a real agent CLI, and everything that compares one sandbox against another, live in
-[`sandbox-probe-reports`](https://github.com/chrisns/sandbox-probe-reports).
+[`sandbox-probe-reports`](https://github.com/controlplaneio/sandbox-probe-reports).
 
 Every report carries an `environment_detection` finding with the host kernel release/version and OS release — captured
 on **every** run — so a behaviour change caused by a kernel or OS upgrade (seccomp/landlock/user-namespace behaviour

--- a/docs/adr/0002-seed-ipc-and-process-targets.md
+++ b/docs/adr/0002-seed-ipc-and-process-targets.md
@@ -12,7 +12,7 @@ Accepted
 > `seed-decoys.sh`, `scan-matrix.yaml`, `site/app.js`,
 > `docs/reporting-site-plan.md`, `CONTEXT.md`'s capability-category table and
 > ADR 0001 — now live in
-> [`sandbox-probe-reports`](https://github.com/chrisns/sandbox-probe-reports).
+> [`sandbox-probe-reports`](https://github.com/controlplaneio/sandbox-probe-reports).
 > The text below is left as it was written.
 
 ## Context


### PR DESCRIPTION
Four documents still sent readers to the fork.

`README.md` line 7 is the front door of this repository and pointed at `chrisns/sandbox-probe-reports`, plus `https://chrisns.github.io/sandbox-probe-reports/` as "the new address". Both are stale. The comparison layer now lives at [controlplaneio/sandbox-probe-reports](https://github.com/controlplaneio/sandbox-probe-reports) and publishes at <https://controlplaneio.github.io/sandbox-probe-reports/>, which is live and currently rendering 132 reports across four scan runs.

`CONTEXT.md`, `docs/CONTRIBUTING.md` and ADR 0002 carried the same links.

Notes under `.scratch/` deliberately keep their fork references. They are the working record of decisions taken while the work was on the fork, and rewriting them would misrepresent when those things were true.

GitHub Pages is now disabled on this repository, so the old `controlplaneio.github.io/sandbox-probe` address no longer resolves. It had been serving a 23 July snapshot from a branch that no longer exists.

https://claude.ai/code/session_0144XqJRJS5Cnt2DLGwYRTSV