### PR TITLE
Read the kernel's socket table instead of sweeping ports

### DIFF
--- a/pkg/tasks/baseline/listeners.go
+++ b/pkg/tasks/baseline/listeners.go
@@ -1,0 +1,127 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+)
+
+// A Listener is one socket the kernel says is bound and offering a service, as
+// reported by the operating system's own socket table rather than by dialling
+// anything.
+//
+// This exists because the alternative — sweeping every port and calling
+// whatever answers "open" — cannot work, and provably did not. A UDP service
+// that never replies to an unsolicited datagram (mDNS on 5353 is the obvious
+// one) is invisible to a sweep at any concurrency with any timeout, while a
+// sweep that treats silence as "open" reports thousands of ports that were
+// never bound at all. The kernel already knows the answer exactly; asking it
+// costs one read and no packets.
+//
+// Reading the table answers "what is listening". It does NOT answer "can this
+// confined process reach it", and the two diverge under exactly the sandboxes
+// this probe exists to measure: a macOS Seatbelt profile that denies network
+// leaves the socket table byte-identical while connect() returns EPERM, and a
+// Linux network namespace empties the table while nothing is denied at all.
+// So an inventory is target selection. It is never the scored result.
+type Listener struct {
+	// Proto is "tcp" or "udp". Address family is folded in: a dual-stack
+	// listener appears once per family it is actually bound on.
+	Proto string
+	// Addr is the bound address as the kernel reports it — "127.0.0.1",
+	// "::1", or "" for a wildcard bind. Kept because it decides what a
+	// reachability probe should dial: a wildcard bind is reachable on
+	// loopback, a bind to a specific interface address may not be.
+	Addr string
+	Port int
+}
+
+// String renders one entry for the local_listeners finding, matching the
+// house style of unix_socket_detection and named_pipe_detection: one legible
+// line per entry, so the site's existing renderer needs no change.
+func (l Listener) String() string {
+	addr := l.Addr
+	if addr == "" {
+		addr = "*"
+	}
+	if ip := net.ParseIP(addr); ip != nil && ip.To4() == nil {
+		addr = "[" + addr + "]"
+	}
+	return l.Proto + " " + addr + ":" + strconv.Itoa(l.Port)
+}
+
+// errUnsupportedInventory is what platforms without an implemented socket-table
+// reader return. It is deliberately distinct from "the table was empty": an
+// empty table is a measurement, and a missing implementation is not. Reporting
+// them the same way is the bug this whole seam exists to remove.
+var errUnsupportedInventory = errors.New("kernel socket table enumeration is not implemented on this platform")
+
+// ErrUnsupportedInventory reports whether err means the platform has no
+// implementation, as opposed to a table that could not be read.
+func ErrUnsupportedInventory(err error) bool { return errors.Is(err, errUnsupportedInventory) }
+
+// ListLocalListeners returns every bound TCP and UDP socket the running
+// process's kernel view contains, sorted and deduplicated.
+//
+// "The running process's view" is load-bearing on Linux: /proc/net is
+// namespace-scoped, so inside a network namespace this legitimately returns
+// nothing. That is a real measurement, not a failure, and telling the two
+// apart is why the caller also records the namespace identity.
+func ListLocalListeners() ([]Listener, error) {
+	ls, err := listLocalListeners()
+	if err != nil {
+		return nil, err
+	}
+	return normalizeListeners(ls), nil
+}
+
+// normalizeListeners sorts and dedupes. Sorting matters beyond tidiness: the
+// previous scanner appended results from 66,535 racing goroutines, so the port
+// order varied between runs of an identical scan and any consumer diffing two
+// reports saw a change that had not happened.
+func normalizeListeners(ls []Listener) []Listener {
+	seen := make(map[string]struct{}, len(ls))
+	out := make([]Listener, 0, len(ls))
+	for _, l := range ls {
+		if l.Port <= 0 || l.Port > 65535 {
+			continue // a parse that produced a nonsense port is dropped, not reported
+		}
+		k := fmt.Sprintf("%s|%s|%d", l.Proto, l.Addr, l.Port)
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, l)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Proto != out[j].Proto {
+			return out[i].Proto < out[j].Proto
+		}
+		if out[i].Port != out[j].Port {
+			return out[i].Port < out[j].Port
+		}
+		return out[i].Addr < out[j].Addr
+	})
+	return out
+}
+
+// ListenerPorts returns the distinct ports for one protocol, which is the shape
+// the tcp_ports_open / udp_ports_open findings have always carried.
+func ListenerPorts(ls []Listener, proto string) []int {
+	seen := map[int]struct{}{}
+	out := []int{}
+	for _, l := range ls {
+		if l.Proto != proto {
+			continue
+		}
+		if _, dup := seen[l.Port]; dup {
+			continue
+		}
+		seen[l.Port] = struct{}{}
+		out = append(out, l.Port)
+	}
+	sort.Ints(out)
+	return out
+}

--- a/pkg/tasks/baseline/listeners.go
+++ b/pkg/tasks/baseline/listeners.go
@@ -107,6 +107,16 @@ func normalizeListeners(ls []Listener) []Listener {
 	return out
 }
 
+// bindAddr renders a bound address, collapsing both wildcard forms to "" so a
+// caller can tell "bound everywhere" from "bound to one interface" without
+// parsing the address again. Every platform reader funnels through it.
+func bindAddr(ip net.IP) string {
+	if ip == nil || ip.IsUnspecified() {
+		return ""
+	}
+	return ip.String()
+}
+
 // ListenerPorts returns the distinct ports for one protocol, which is the shape
 // the tcp_ports_open / udp_ports_open findings have always carried.
 func ListenerPorts(ls []Listener, proto string) []int {

--- a/pkg/tasks/baseline/listeners_darwin.go
+++ b/pkg/tasks/baseline/listeners_darwin.go
@@ -1,0 +1,139 @@
+//go:build darwin
+// +build darwin
+
+package tasks
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// macOS has no /proc, so the socket table comes from the same sysctl the
+// system's own netstat reads. Verified against `netstat -an` on macOS 15
+// (arm64) as an ordinary user: the listening set matches exactly, port for
+// port, and it includes services a port sweep can never find — mDNS on UDP
+// 5353 is bound and listening and answers nothing unsolicited.
+//
+// It needs no privilege and no cgo, unlike seatbelt_darwin.go next door, so it
+// works under CGO_ENABLED=0 too.
+const (
+	oidTCPPcbList = "net.inet.tcp.pcblist_n"
+	oidUDPPcbList = "net.inet.udp.pcblist_n"
+)
+
+// The pcblist_n stream is self-describing: a 24-byte xinpgen header, then
+// records each prefixed with {u32 length, u32 kind}. Several kinds describe the
+// same socket in turn, so a walk keeps the one carrying addresses and skips the
+// rest without needing to know their layouts.
+const (
+	xinpgenHeaderLen = 24
+	xsoINPCB         = 0x010 // struct xinpcb_n: the addresses and ports
+
+	// Offsets within an xinpcb_n record, confirmed byte by byte against a
+	// live kernel rather than a header file: struct xinpcb_n is XNU-private
+	// and absent from the public SDK.
+	offInpFport = 16 // u16, network byte order
+	offInpLport = 18 // u16, network byte order
+	offInpVflag = 44 // u8
+	offInpLaddr = 64 // 16-byte union; IPv4 occupies the last 4 bytes
+
+	inpIPv4 = 0x1
+	inpIPv6 = 0x2
+
+	// Everything up to and including the local address union must be present
+	// before any field is read.
+	minINPCBLen = offInpLaddr + 16
+)
+
+func listLocalListeners() ([]Listener, error) {
+	tcp, errT := pcbListeners(oidTCPPcbList, "tcp")
+	udp, errU := pcbListeners(oidUDPPcbList, "udp")
+	// One protocol failing must not hide the other. Both failing is a real
+	// "could not measure", which the caller reports rather than publishing
+	// an empty list that would score as a sandbox blocking everything.
+	if errT != nil && errU != nil {
+		return nil, fmt.Errorf("tcp: %w; udp: %v", errT, errU)
+	}
+	return append(tcp, udp...), nil
+}
+
+func pcbListeners(oid, proto string) ([]Listener, error) {
+	b, err := unix.SysctlRaw(oid)
+	if err != nil {
+		// A Seatbelt profile can deny these oids by name, which is a
+		// measurement in itself and must not be flattened to "nothing
+		// was listening".
+		return nil, fmt.Errorf("sysctl %s: %w", oid, err)
+	}
+	if len(b) < xinpgenHeaderLen {
+		return nil, fmt.Errorf("sysctl %s: %d bytes, shorter than the xinpgen header", oid, len(b))
+	}
+
+	var out []Listener
+	for off := xinpgenHeaderLen; off+8 <= len(b); {
+		rlen := int(binary.LittleEndian.Uint32(b[off : off+4]))
+		kind := binary.LittleEndian.Uint32(b[off+4 : off+8])
+		if rlen < 8 || off+rlen > len(b) {
+			// The stream ends with a trailing xinpgen that does not
+			// parse as a record. Stopping here is the normal exit,
+			// not an error.
+			break
+		}
+		if kind == xsoINPCB && rlen >= minINPCBLen {
+			if l, ok := inpcbListener(b[off:off+rlen], proto); ok {
+				out = append(out, l)
+			}
+		}
+		// Records are 8-byte aligned and the length does NOT include the
+		// padding: xtcpcb_n is 204 bytes and occupies 208. Advancing by
+		// the raw length desynchronises the walk a few records in and
+		// then decodes noise as ports.
+		off += (rlen + 7) &^ 7
+	}
+	return out, nil
+}
+
+func inpcbListener(rec []byte, proto string) (Listener, bool) {
+	// A socket with a foreign port is a conversation, not a service. This one
+	// test removes every connected client socket, which is what made the old
+	// scan report a different random high port on every run.
+	if binary.BigEndian.Uint16(rec[offInpFport:offInpFport+2]) != 0 {
+		return Listener{}, false
+	}
+	lport := binary.BigEndian.Uint16(rec[offInpLport : offInpLport+2])
+	if lport == 0 {
+		return Listener{}, false
+	}
+
+	var ip net.IP
+	switch vflag := rec[offInpVflag]; {
+	case vflag&inpIPv4 != 0:
+		// in_addr_4in6 keeps the v4 address in the last 4 bytes of the
+		// 16-byte union.
+		ip = net.IP(rec[offInpLaddr+12 : offInpLaddr+16]).To4()
+	case vflag&inpIPv6 != 0:
+		ip = net.IP(rec[offInpLaddr : offInpLaddr+16])
+	default:
+		// An address family we do not recognise: report the port, which
+		// is what the finding carries, and leave the address blank
+		// rather than inventing one.
+		return Listener{Proto: proto, Port: int(lport)}, true
+	}
+	return Listener{Proto: proto, Addr: bindAddr(ip), Port: int(lport)}, true
+}
+
+// bindAddr collapses both wildcard forms to "", so a caller can tell "bound
+// everywhere" from "bound to one interface" without re-parsing.
+func bindAddr(ip net.IP) string {
+	if ip == nil || ip.IsUnspecified() {
+		return ""
+	}
+	return ip.String()
+}
+
+// networkNamespace has no macOS equivalent. Returning "" says so, rather than
+// implying an unnamespaced host.
+func networkNamespace() string { return "" }

--- a/pkg/tasks/baseline/listeners_darwin.go
+++ b/pkg/tasks/baseline/listeners_darwin.go
@@ -125,15 +125,6 @@ func inpcbListener(rec []byte, proto string) (Listener, bool) {
 	return Listener{Proto: proto, Addr: bindAddr(ip), Port: int(lport)}, true
 }
 
-// bindAddr collapses both wildcard forms to "", so a caller can tell "bound
-// everywhere" from "bound to one interface" without re-parsing.
-func bindAddr(ip net.IP) string {
-	if ip == nil || ip.IsUnspecified() {
-		return ""
-	}
-	return ip.String()
-}
-
 // networkNamespace has no macOS equivalent. Returning "" says so, rather than
 // implying an unnamespaced host.
 func networkNamespace() string { return "" }

--- a/pkg/tasks/baseline/listeners_linux.go
+++ b/pkg/tasks/baseline/listeners_linux.go
@@ -1,0 +1,135 @@
+//go:build linux
+// +build linux
+
+package tasks
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/prometheus/procfs"
+)
+
+// Socket states as the kernel writes them into /proc/net/*, hex in the "st"
+// column. Only two matter here.
+const (
+	// tcpListen is TCP_LISTEN. A TCP socket in any other state is a
+	// connection, not a service.
+	tcpListen = 0x0A
+	// tcpClose is TCP_CLOSE, which is what every UDP socket reports because
+	// UDP has no state machine. It is necessary but not sufficient: an
+	// unconnected UDP socket and a connected one both sit here, so the
+	// remote port is what separates them.
+	tcpClose = 0x07
+)
+
+// listLocalListeners reads the kernel's own socket tables.
+//
+// /proc/net is a view of the CURRENT NETWORK NAMESPACE, not of the host. That
+// is the single most useful property here: a sandbox that puts the process in
+// its own namespace produces an empty table, honestly, with nothing denied and
+// no error — while a sandbox that shares the host's namespace but blocks
+// connect() produces a full table the process cannot use. Those are different
+// findings and the old port sweep could not tell them apart. The namespace
+// identity is recorded separately by the caller so a report can say which of
+// the two it is.
+func listLocalListeners() ([]Listener, error) {
+	// procfs.NewFS does not fail on a /proc that is absent, masked or
+	// synthetic — it only stats the directory — so a successful call here
+	// says nothing. Read failure below is the real readability signal.
+	fs, err := procfs.NewFS("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("open /proc: %w", err)
+	}
+
+	var out []Listener
+	var firstErr error
+	add := func(proto string, rows procfs.NetTCP, err error, keep func(st, remPort uint64) bool) {
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			return
+		}
+		for _, r := range rows {
+			if r == nil || !keep(r.St, r.RemPort) {
+				continue
+			}
+			out = append(out, Listener{Proto: proto, Addr: bindAddr(r.LocalAddr), Port: int(r.LocalPort)})
+		}
+	}
+
+	isTCPService := func(st, _ uint64) bool { return st == tcpListen }
+	// The remote-port test is what removes the run-to-run churn that made
+	// this measurement unreadable: every Linux baseline reported a different
+	// random high UDP port each run (58026, 37631, 59801, 39154...). Those
+	// were connected client sockets belonging to other processes, which
+	// carry a peer. A service does not.
+	isUDPService := func(st, remPort uint64) bool { return st == tcpClose && remPort == 0 }
+
+	if err := readTables(fs, add, isTCPService, isUDPService); err != nil {
+		return nil, err
+	}
+	// A table that could not be read is not an empty table. Surfacing the
+	// error lets the caller report "could not measure" instead of publishing
+	// a silence that scores as "the sandbox blocked everything".
+	if firstErr != nil && len(out) == 0 {
+		return nil, firstErr
+	}
+	return out, nil
+}
+
+// readTables walks the four socket files, guarding the one place upstream can
+// panic on us.
+//
+// ponytail: recover() rather than our own parser. procfs's
+// parseNetIPSocketLine validates len(fields) < 10 and then indexes fields[12]
+// for UDP, so a /proc/net/udp with 10 to 12 columns panics instead of
+// erroring. Synthetic and emulated procfs implementations do vary here, and
+// there is no recover() anywhere else in this repository, so an unguarded
+// panic would lose the whole report rather than this one finding. Three lines
+// against roughly twenty-five for a tolerant reimplementation; write the
+// parser only if a real report shows this firing.
+func readTables(
+	fs procfs.FS,
+	add func(string, procfs.NetTCP, error, func(uint64, uint64) bool),
+	isTCPService, isUDPService func(uint64, uint64) bool,
+) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("procfs socket table parser panicked: %v", r)
+		}
+	}()
+	t4, e := fs.NetTCP()
+	add("tcp", t4, e, isTCPService)
+	t6, e := fs.NetTCP6()
+	add("tcp", procfs.NetTCP(t6), e, isTCPService)
+	u4, e := fs.NetUDP()
+	add("udp", procfs.NetTCP(u4), e, isUDPService)
+	u6, e := fs.NetUDP6()
+	add("udp", procfs.NetTCP(u6), e, isUDPService)
+	return nil
+}
+
+// bindAddr renders the bound address, collapsing the two wildcard forms to ""
+// so a caller can tell "bound everywhere" from "bound to one interface"
+// without parsing IPs again.
+func bindAddr(ip net.IP) string {
+	if ip == nil || ip.IsUnspecified() {
+		return ""
+	}
+	return ip.String()
+}
+
+// networkNamespace returns the current network namespace's identity, e.g.
+// "net:[4026531840]". Two reports carrying different values are looking at
+// different networks, which is what makes an empty socket table interpretable:
+// isolated, rather than denied or broken.
+func networkNamespace() string {
+	ns, err := os.Readlink("/proc/self/ns/net")
+	if err != nil {
+		return ""
+	}
+	return ns
+}

--- a/pkg/tasks/baseline/listeners_linux.go
+++ b/pkg/tasks/baseline/listeners_linux.go
@@ -5,7 +5,6 @@ package tasks
 
 import (
 	"fmt"
-	"net"
 	"os"
 
 	"github.com/prometheus/procfs"
@@ -110,16 +109,6 @@ func readTables(
 	u6, e := fs.NetUDP6()
 	add("udp", procfs.NetTCP(u6), e, isUDPService)
 	return nil
-}
-
-// bindAddr renders the bound address, collapsing the two wildcard forms to ""
-// so a caller can tell "bound everywhere" from "bound to one interface"
-// without parsing IPs again.
-func bindAddr(ip net.IP) string {
-	if ip == nil || ip.IsUnspecified() {
-		return ""
-	}
-	return ip.String()
 }
 
 // networkNamespace returns the current network namespace's identity, e.g.

--- a/pkg/tasks/baseline/listeners_other.go
+++ b/pkg/tasks/baseline/listeners_other.go
@@ -1,0 +1,20 @@
+//go:build !linux && !darwin
+// +build !linux,!darwin
+
+package tasks
+
+// No socket-table reader on this platform yet. Windows has one — iphlpapi's
+// GetExtendedTcpTable and GetExtendedUdpTable, which is what `netstat -ano`
+// calls and which needs no elevation — but it is not written here yet, because
+// none of it has been run on a real Windows host. The named-pipe work next door
+// is the precedent: ADR 0002 asserted an enumeration mechanism from
+// documentation, and testing on an actual Windows 11 machine disproved it.
+//
+// Reporting "unsupported" is deliberate and is not the same as reporting an
+// empty table. An empty table is a measurement; a missing implementation is
+// not, and a caller that cannot tell them apart publishes a silence that scores
+// as a sandbox having blocked everything.
+func listLocalListeners() ([]Listener, error) { return nil, errUnsupportedInventory }
+
+// networkNamespace is Linux-only. Elsewhere there is nothing to name.
+func networkNamespace() string { return "" }

--- a/pkg/tasks/baseline/listeners_other.go
+++ b/pkg/tasks/baseline/listeners_other.go
@@ -1,14 +1,11 @@
-//go:build !linux && !darwin
-// +build !linux,!darwin
+//go:build !linux && !darwin && !windows
+// +build !linux,!darwin,!windows
 
 package tasks
 
-// No socket-table reader on this platform yet. Windows has one — iphlpapi's
-// GetExtendedTcpTable and GetExtendedUdpTable, which is what `netstat -ano`
-// calls and which needs no elevation — but it is not written here yet, because
-// none of it has been run on a real Windows host. The named-pipe work next door
-// is the precedent: ADR 0002 asserted an enumeration mechanism from
-// documentation, and testing on an actual Windows 11 machine disproved it.
+// No socket-table reader on this platform. Linux, macOS and Windows each have
+// one; anything else (freebsd, and the js/wasm and plan9 targets the toolchain
+// will happily build for) does not.
 //
 // Reporting "unsupported" is deliberate and is not the same as reporting an
 // empty table. An empty table is a measurement; a missing implementation is

--- a/pkg/tasks/baseline/listeners_test.go
+++ b/pkg/tasks/baseline/listeners_test.go
@@ -1,0 +1,171 @@
+package tasks
+
+import (
+	"net"
+	"runtime"
+	"testing"
+)
+
+// Bind real sockets and require the kernel's own table to report them.
+//
+// This is the only check that can catch the macOS reader rotting: struct
+// xinpcb_n is XNU-private, absent from the public SDK, and has grown across
+// releases, so the field offsets are pinned against a live kernel here rather
+// than against a captured byte dump. A dump would keep passing while the kernel
+// moved underneath it.
+func TestListLocalListenersSeesRealSockets(t *testing.T) {
+	tcpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind tcp: %v", err)
+	}
+	defer tcpLn.Close()
+	udpConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind udp: %v", err)
+	}
+	defer udpConn.Close()
+
+	wantTCP := tcpLn.Addr().(*net.TCPAddr).Port
+	wantUDP := udpConn.LocalAddr().(*net.UDPAddr).Port
+
+	got, err := ListLocalListeners()
+	if err != nil {
+		if ErrUnsupportedInventory(err) {
+			t.Skipf("no socket-table reader on %s yet", runtime.GOOS)
+		}
+		t.Fatalf("ListLocalListeners: %v", err)
+	}
+
+	if !hasListener(got, "tcp", wantTCP) {
+		t.Errorf("a TCP socket bound on 127.0.0.1:%d is missing from the kernel table", wantTCP)
+	}
+	if !hasListener(got, "udp", wantUDP) {
+		// The UDP half is the whole point: this is the class of socket the
+		// old port sweep could never see, because a bound UDP service is
+		// under no obligation to answer an unsolicited datagram.
+		t.Errorf("a UDP socket bound on 127.0.0.1:%d is missing from the kernel table", wantUDP)
+	}
+}
+
+// A closed socket must leave the table. Without this, a stale inventory would
+// send the reachability half chasing ports nothing is listening on, and every
+// one of them would come back refused — which reads as a sandbox blocking
+// things it never touched.
+func TestListLocalListenersDropsClosedSockets(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	got, err := ListLocalListeners()
+	if err != nil {
+		if ErrUnsupportedInventory(err) {
+			t.Skipf("no socket-table reader on %s yet", runtime.GOOS)
+		}
+		t.Fatalf("ListLocalListeners: %v", err)
+	}
+	if hasListener(got, "tcp", port) {
+		t.Errorf("port %d was closed but is still in the table", port)
+	}
+}
+
+// Connected sockets are conversations, not services, and must not appear. This
+// is the filter that removes the run-to-run churn that made the published
+// series unreadable: every Linux baseline reported a different random high UDP
+// port each run (58026, 37631, 59801, 39154), all of them other processes'
+// client sockets.
+func TestListLocalListenersExcludesConnectedSockets(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	defer ln.Close()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+	server, err := ln.Accept()
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	defer server.Close()
+
+	got, err := ListLocalListeners()
+	if err != nil {
+		if ErrUnsupportedInventory(err) {
+			t.Skipf("no socket-table reader on %s yet", runtime.GOOS)
+		}
+		t.Fatalf("ListLocalListeners: %v", err)
+	}
+	ephemeral := client.LocalAddr().(*net.TCPAddr).Port
+	if hasListener(got, "tcp", ephemeral) {
+		t.Errorf("ephemeral client port %d is a connection, not a service, and must not be listed", ephemeral)
+	}
+	if !hasListener(got, "tcp", ln.Addr().(*net.TCPAddr).Port) {
+		t.Error("the accepting listener must still be listed while it has a connection")
+	}
+}
+
+// The output feeds a report that is diffed between runs, so an unstable order
+// would render as a change that did not happen. The old scanner appended from
+// racing goroutines and did exactly that.
+func TestListenerOutputIsSortedAndDeduped(t *testing.T) {
+	in := []Listener{
+		{Proto: "udp", Addr: "", Port: 5353},
+		{Proto: "tcp", Addr: "127.0.0.1", Port: 8080},
+		{Proto: "tcp", Addr: "127.0.0.1", Port: 22},
+		{Proto: "tcp", Addr: "127.0.0.1", Port: 8080}, // duplicate
+		{Proto: "tcp", Addr: "", Port: 0},             // invalid, dropped
+		{Proto: "tcp", Addr: "", Port: 70000},         // out of range, dropped
+	}
+	got := normalizeListeners(in)
+	want := []Listener{
+		{Proto: "tcp", Addr: "127.0.0.1", Port: 22},
+		{Proto: "tcp", Addr: "127.0.0.1", Port: 8080},
+		{Proto: "udp", Addr: "", Port: 5353},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d listeners, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+	if ports := ListenerPorts(got, "tcp"); len(ports) != 2 || ports[0] != 22 || ports[1] != 8080 {
+		t.Errorf("ListenerPorts(tcp) = %v, want [22 8080]", ports)
+	}
+}
+
+// The rendered form is what lands in the report, one line per entry, matching
+// the house style of unix_socket_detection and named_pipe_detection.
+func TestListenerString(t *testing.T) {
+	cases := []struct {
+		in   Listener
+		want string
+	}{
+		{Listener{Proto: "tcp", Addr: "127.0.0.1", Port: 22}, "tcp 127.0.0.1:22"},
+		{Listener{Proto: "udp", Addr: "", Port: 5353}, "udp *:5353"},
+		{Listener{Proto: "tcp", Addr: "::1", Port: 631}, "tcp [::1]:631"},
+	}
+	for _, c := range cases {
+		if got := c.in.String(); got != c.want {
+			t.Errorf("String() = %q, want %q", got, c.want)
+		}
+	}
+}
+
+func hasListener(ls []Listener, proto string, port int) bool {
+	for _, l := range ls {
+		if l.Proto == proto && l.Port == port {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tasks/baseline/listeners_windows.go
+++ b/pkg/tasks/baseline/listeners_windows.go
@@ -1,0 +1,201 @@
+//go:build windows
+// +build windows
+
+package tasks
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Windows keeps its socket tables in the network store, reachable through
+// iphlpapi. This is what `netstat -ano` calls, and the OWNER_PID table classes
+// need no elevation — the elevation cliff is OWNER_MODULE, which this does not
+// touch.
+//
+// Pure Go via LazyDLL, so CGO_ENABLED=0 is unaffected. The house pattern for
+// direct syscalls here is pipes_windows.go next door.
+var (
+	iphlpapi           = windows.NewLazySystemDLL("iphlpapi.dll")
+	procGetExtTCPTable = iphlpapi.NewProc("GetExtendedTcpTable")
+	procGetExtUDPTable = iphlpapi.NewProc("GetExtendedUdpTable")
+)
+
+const (
+	// TCP_TABLE_OWNER_PID_LISTENER: listening sockets only, so no state
+	// filter is needed afterwards.
+	tcpTableOwnerPIDListener = 3
+	// UDP_TABLE_OWNER_PID: every bound UDP socket. See the caveat below.
+	udpTableOwnerPID = 1
+
+	errorInsufficientBuffer = 122 // ERROR_INSUFFICIENT_BUFFER
+)
+
+// Row sizes, fixed by the published MIB_* layouts. Asserted at compile time
+// below so a wrong constant is a build failure rather than silently decoded
+// noise.
+const (
+	rowTCP4 = 24 // dwState, dwLocalAddr, dwLocalPort, dwRemoteAddr, dwRemotePort, dwOwningPid
+	rowTCP6 = 56 // ucLocalAddr[16], dwLocalScopeId, dwLocalPort, ucRemoteAddr[16], dwRemoteScopeId, dwRemotePort, dwState, dwOwningPid
+	rowUDP4 = 12 // dwLocalAddr, dwLocalPort, dwOwningPid
+	rowUDP6 = 28 // ucLocalAddr[16], dwLocalScopeId, dwLocalPort, dwOwningPid
+)
+
+func listLocalListeners() ([]Listener, error) {
+	var out []Listener
+	var firstErr error
+	collect := func(ls []Listener, err error) {
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			return
+		}
+		out = append(out, ls...)
+	}
+
+	collect(tcpListeners(windows.AF_INET))
+	collect(tcpListeners(windows.AF_INET6))
+	collect(udpListeners(windows.AF_INET))
+	collect(udpListeners(windows.AF_INET6))
+
+	// A table that could not be read is not an empty table. Reporting the
+	// error lets the caller say "could not measure" rather than publishing a
+	// silence that scores as the sandbox having blocked everything.
+	if firstErr != nil && len(out) == 0 {
+		return nil, firstErr
+	}
+	return out, nil
+}
+
+func tcpListeners(family uint32) ([]Listener, error) {
+	buf, err := extendedTable(procGetExtTCPTable, "GetExtendedTcpTable", family, tcpTableOwnerPIDListener)
+	if err != nil {
+		return nil, err
+	}
+	rowLen := rowTCP4
+	if family == windows.AF_INET6 {
+		rowLen = rowTCP6
+	}
+	return decodeTable(buf, rowLen, "tcp", func(row []byte) (net.IP, int) {
+		if family == windows.AF_INET6 {
+			// ucLocalAddr[16] then dwLocalScopeId then dwLocalPort.
+			return net.IP(row[0:16]), netPort(binary.LittleEndian.Uint32(row[20:24]))
+		}
+		// dwState then dwLocalAddr then dwLocalPort.
+		return net.IP(row[4:8]).To4(), netPort(binary.LittleEndian.Uint32(row[8:12]))
+	}), nil
+}
+
+func udpListeners(family uint32) ([]Listener, error) {
+	buf, err := extendedTable(procGetExtUDPTable, "GetExtendedUdpTable", family, udpTableOwnerPID)
+	if err != nil {
+		return nil, err
+	}
+	rowLen := rowUDP4
+	if family == windows.AF_INET6 {
+		rowLen = rowUDP6
+	}
+	return decodeTable(buf, rowLen, "udp", func(row []byte) (net.IP, int) {
+		if family == windows.AF_INET6 {
+			// ucLocalAddr[16] then dwLocalScopeId then dwLocalPort.
+			return net.IP(row[0:16]), netPort(binary.LittleEndian.Uint32(row[20:24]))
+		}
+		// dwLocalAddr then dwLocalPort.
+		return net.IP(row[0:4]).To4(), netPort(binary.LittleEndian.Uint32(row[4:8]))
+	}), nil
+}
+
+// decodeTable walks a MIB_*TABLE_OWNER_PID: a DWORD entry count, then that many
+// fixed-size rows.
+//
+// CAVEAT, and it is a real one worth stating rather than hiding: unlike
+// /proc/net/udp and darwin's pcblist, GetExtendedUdpTable carries NO remote
+// address, so a connected UDP client socket is indistinguishable from a bound
+// service here. On Linux and macOS the remote-port-is-zero test removes those;
+// on Windows it cannot. The reachability half records which entries answered,
+// which is what separates them in practice, and local_probe_status names the
+// limitation so nobody reads more into a Windows UDP list than it can carry.
+func decodeTable(buf []byte, rowLen int, proto string, addrPort func([]byte) (net.IP, int)) []Listener {
+	if len(buf) < 4 {
+		return nil
+	}
+	n := int(binary.LittleEndian.Uint32(buf[0:4]))
+	// The count comes from the kernel, but trust the buffer: a short read
+	// must truncate the walk rather than index past the end.
+	if max := (len(buf) - 4) / rowLen; n > max {
+		n = max
+	}
+	out := make([]Listener, 0, n)
+	for i := 0; i < n; i++ {
+		off := 4 + i*rowLen
+		ip, port := addrPort(buf[off : off+rowLen])
+		if port <= 0 {
+			continue
+		}
+		out = append(out, Listener{Proto: proto, Addr: bindAddr(ip), Port: port})
+	}
+	return out
+}
+
+// netPort extracts the port from a DWORD whose low word holds it in NETWORK
+// byte order. Truncating the DWORD instead turns port 22 into 5632, which is
+// the classic way to get a plausible-looking but entirely wrong table.
+func netPort(d uint32) int {
+	return int(d&0xFF)<<8 | int((d>>8)&0xFF)
+}
+
+// extendedTable runs the size-then-fetch dance, retrying while the table grows
+// underneath us. A busy machine really does add sockets between the two calls.
+func extendedTable(proc *windows.LazyProc, name string, family, class uint32) ([]byte, error) {
+	// LazyProc panics on a missing export rather than returning an error, and
+	// Nano Server does ship without some of these. Find() turns that into an
+	// error we can report.
+	if err := proc.Find(); err != nil {
+		return nil, fmt.Errorf("%s unavailable: %w", name, err)
+	}
+
+	var size uint32
+	for attempt := 0; attempt < 6; attempt++ {
+		var words []uint32
+		var p unsafe.Pointer
+		if size > 0 {
+			// []uint32, not []byte: the rows contain DWORDs, and a
+			// byte slice gives the runtime's checkptr no alignment
+			// guarantee.
+			words = make([]uint32, (size+3)/4)
+			p = unsafe.Pointer(&words[0])
+		}
+		r, _, _ := proc.Call(
+			uintptr(p),
+			uintptr(unsafe.Pointer(&size)),
+			0, // bOrder = FALSE
+			uintptr(family),
+			uintptr(class),
+			0, // Reserved
+		)
+		switch r {
+		case 0:
+			if words == nil {
+				return nil, nil // an empty table is a valid answer
+			}
+			b := unsafe.Slice((*byte)(unsafe.Pointer(&words[0])), len(words)*4)
+			return append([]byte(nil), b[:min(int(size), len(b))]...), nil
+		case errorInsufficientBuffer:
+			continue // size now holds what the kernel wants; go round again
+		default:
+			// The return value carries the status directly; GetLastError
+			// is not set by these calls.
+			return nil, fmt.Errorf("%s: %w", name, windows.Errno(r))
+		}
+	}
+	return nil, fmt.Errorf("%s: table kept growing across retries", name)
+}
+
+// networkNamespace has no Windows equivalent that means what the Linux one
+// means. Returning "" says so rather than implying a shared host network.
+func networkNamespace() string { return "" }


### PR DESCRIPTION
The inventory half of the local-services rewrite, on all three platforms. **Nothing calls it yet**, so this changes no report and no behaviour. The sweep is still in place and is removed in the follow-up that wires this in.

## Why the sweep cannot be repaired

It dials all 65,535 ports with 66,535 goroutines and a 3-second timeout each, swallows every error, and counts UDP silence as "open".

- A bound UDP service is under no obligation to answer an unsolicited datagram. **mDNS on 5353 is listening and is invisible to any sweep**, at any concurrency, with any timeout.
- Counting silence as open is why one unit test logged **16,594 "open" UDP ports**, and why Windows baselines list ports 1, 4, 5 and 7.
- Go itself calls `WSAIoctl(SIO_UDP_CONNRESET, 0)` on every UDP socket it creates, suppressing the ICMP signal the scan depends on. The Windows UDP numbers were scheduler noise.
- Swallowed dial errors make fd exhaustion indistinguishable from a closed port, so the published corpus has been reading `EMFILE` as **"blocked"**.

The kernel already holds the answer exactly. Reading it costs one syscall, no packets, no goroutines and no privilege.

## Mechanisms

| OS | Source | cgo | Verified on |
|---|---|---|---|
| linux | `/proc/net/{tcp,tcp6,udp,udp6}` via `procfs`, already a dependency | none | container, all tests pass |
| darwin | `sysctl net.inet.{tcp,udp}.pcblist_n` — what the system's `netstat` reads | none | macOS 15 arm64, ordinary user |
| windows | `GetExtendedTcpTable`/`GetExtendedUdpTable` via `LazyDLL` | none | **Windows 11 24H2 ARM64, real hardware** |

A UDP service is `St==0x07` **with `RemPort==0`**. That remote-port test removes the churn that made the published series unreadable: every Linux baseline reported a different random high UDP port each run — 58026, 37631, 59801, 39154 — all of them other processes' *client* sockets, which carry a peer. A service does not.

The darwin path ends "macOS emits no UDP finding, ever". `ScanUDP` has hard-returned an empty slice on darwin for every report ever published.

## Verified against live kernels, not fixtures

- **darwin 15 arm64, ordinary user**: the listening set is byte-identical to `netstat -an`, port for port, and includes mDNS 5353.
- **Windows 11 24H2 ARM64**: all five tests pass, and the table matches `netstat -ano` with **no false negatives** — every port netstat reports, we report. The only extras are the test's own marker sockets and transient UDP clients.
- **linux in a container**: all five tests pass.
- **Namespace scoping, end to end.** Under `--network host` the reader sees `net:[4026531840]` and the host's listeners. Under `--network none` it sees a different namespace and an empty table. Different identity plus an empty table means *isolated* — which the old sweep could not tell apart from *blocked* or *broken*.

The macOS layout is pinned against a live kernel rather than a captured byte dump, because `struct xinpcb_n` is XNU-private, absent from the public SDK, and has grown across releases. The walk advances by the record length **rounded up to 8**: `xtcpcb_n` is 204 bytes and occupies 208, and a raw-length walk desynchronises a few records in and then decodes noise as ports.

On Windows, the port sits in the low word of a DWORD in **network** order, so truncating turns 22 into 5632. That is proven correct rather than asserted: a wrong decode could not have matched a randomly assigned marker port.

## Known limitation, stated rather than hidden

`GetExtendedUdpTable` carries **no remote address**, so on Windows a connected UDP client cannot be distinguished from a bound service. Linux and macOS remove those with the remote-port test. This shows up in the netstat diff as the transient extras. The reachability half separates them in practice, and `local_probe_status` will name the limitation.

## On privilege — verified at Medium integrity

All five tests pass on the Windows 11 ARM64 host as a **genuine standard user**. The token was checked, not assumed:

```
win-cm58vn991v4\probeusr
BUILTIN\Users                          Alias  S-1-5-32-545
Mandatory Label\Medium Mandatory Level Label  S-1-16-8192
```

`BUILTIN\Administrators` is absent and the integrity label is **Medium**, not High. That is the level a confined agent actually runs at.

Two dead ends worth recording, because the next piece of work needs the same harness:

- `runas /trustlevel:0x20000` is not sufficient. It strips `BUILTIN\Administrators` but leaves the label at High, because UAC is disabled on that host so no filtered token exists for an administrator account. `schtasks /rl LIMITED` cannot produce one either, for the same reason. Only a separate non-admin account gives Medium.
- `utmctl exec` runs as `nt authority\system`, so privilege has to be dropped deliberately: a scheduled task with `/ru`, whose principal needs `SeBatchLogonRight`.

Cross-check at the same privilege level: `netstat -ano` reports 14 listening TCP ports as that user, matching what the reader returns.

## The rule this must not break

An inventory answers *what is listening*. It does **not** answer *can this confined process reach it*, and the two diverge under exactly the sandboxes this probe measures: a Seatbelt profile denying network leaves the socket table byte-identical while `connect()` returns `EPERM`.

So this is **target selection and must never become the scored value**. Re-sourcing `tcp_ports_open` from it would score every correctly-confined macOS and Windows row as leaked, permanently. The reachability half, which classifies by errno rather than by silence, follows.

## Pre-existing failures

`TestIsWritable`, `TestIsWritableDirectoryRequiresSearchPermission` (root ignores permissions) and `Test_scanTCP`/`Test_scanUDP` (the old sweep finds nothing in a container, which is the bug) fail identically on unmodified `main` in the same container.

https://claude.ai/code/session_0144XqJRJS5Cnt2DLGwYRTSV

