### PR TITLE
Classify what stopped a connection, and delete the port sweep

### DIFF
--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	tasks "github.com/controlplaneio/sandbox-probe/v6/pkg/tasks/baseline"
@@ -67,6 +68,29 @@ var servePipeCmd = &cobra.Command{
 	},
 }
 
+// servePortCmd is how a port decoy stays alive. A listening socket exists only
+// while something holds it, so "seed" spawns the probe again in this mode, one
+// process per decoy, each exiting on its own after the given lifetime. Same
+// shape as serve-pipe, and hidden for the same reason: it is an implementation
+// detail of "seed", not something to run by hand.
+var servePortCmd = &cobra.Command{
+	Use:    "serve-port <port> <lifetime>",
+	Short:  "Hold one decoy TCP port open until the lifetime expires (used by seed)",
+	Hidden: true,
+	Args:   cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		port, err := strconv.Atoi(args[0])
+		if err != nil {
+			return err
+		}
+		d, err := time.ParseDuration(args[1])
+		if err != nil {
+			return err
+		}
+		return tasks.ServePort(port, d)
+	},
+}
+
 func init() {
-	rootCmd.AddCommand(seedCmd, cleanupCmd, servePipeCmd)
+	rootCmd.AddCommand(seedCmd, cleanupCmd, servePipeCmd, servePortCmd)
 }

--- a/pkg/tasks/baseline.go
+++ b/pkg/tasks/baseline.go
@@ -178,46 +178,83 @@ func (t *NetworkTask) Run(ctx context.Context, ti Inputs) ([]*reportv1.Finding, 
 		Value:       connValue,
 	})
 
-	// TCPPORTSOPEN
-	log.Info().Str("host", t.testHost).Msg("Scanning TCP ports")
-	tcpPorts := baselineTasks.ScanTCP(t.testHost)
-	log.Info().Int("open_tcp_ports", len(tcpPorts)).Msg("TCP scan completed")
+	// Local services: ask the kernel what is listening, then find out what
+	// this process can actually reach. Two questions, reported separately,
+	// because they diverge under exactly the sandboxes this probe measures.
+	svc := baselineTasks.MeasureLocalServices()
+	log.Info().
+		Interface("table", svc.Status["table"]).
+		Interface("source", svc.Status["source"]).
+		Interface("listeners", svc.Status["listeners_found"]).
+		Interface("udp_feedback", svc.Status["udp_feedback"]).
+		Msg("Local service scan completed")
 
-	if len(tcpPorts) > 0 {
-		tcpValue, err := structpb.NewValue(intSliceToInterface(tcpPorts))
+	// LOCALLISTENERS — the inventory. Emitted whenever the table was read,
+	// including empty, because an empty namespace is a real observation.
+	if svc.Status["table"] == "read" {
+		names := make([]string, 0, len(svc.Listeners))
+		for _, l := range svc.Listeners {
+			names = append(names, l.String())
+		}
+		lv, err := structpb.NewValue(stringSliceToInterface(names))
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to convert TCP ports to protobuf value")
+			log.Error().Err(err).Msg("Failed to convert local listeners to protobuf value")
 			return nil, err
 		}
 		findings = append(findings, &reportv1.Finding{
-			FindingType: TCPPORTSOPEN,
+			FindingType: LOCALLISTENERS,
 			Task:        t.GetName(),
-			Description: "Open TCP ports",
-			Value:       tcpValue,
+			Description: "Local listening sockets (inventory, not a capability)",
+			Value:       lv,
 		})
 	}
 
-	// UDPPORTSOPEN
-	log.Info().Str("host", t.testHost).Msg("Scanning UDP ports")
-	udpPorts := baselineTasks.ScanUDP(t.testHost)
-	log.Info().Int("open_udp_ports", len(udpPorts)).Msg("UDP scan completed")
-
-	if len(udpPorts) > 0 {
-		udpValue, err := structpb.NewValue(intSliceToInterface(udpPorts))
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to convert UDP ports to protobuf value")
+	// TCPPORTSOPEN / UDPPORTSOPEN — the scored halves. Same shape and same
+	// meaning as before: ports this process reached. Emitted even when
+	// empty, because a scan that ran and found nothing is a real negative
+	// and is what makes a baseline comparison mean anything. Omitted only
+	// when the measurement could not conclude, which the site reads as
+	// unmeasured rather than as blocked.
+	if ports, ok := svc.TCPPorts(); ok {
+		if err := appendPorts(&findings, t.GetName(), TCPPORTSOPEN, "Reachable TCP ports", ports); err != nil {
 			return nil, err
 		}
-		findings = append(findings, &reportv1.Finding{
-			FindingType: UDPPORTSOPEN,
-			Task:        t.GetName(),
-			Description: "Open UDP ports",
-			Value:       udpValue,
-		})
 	}
+	if ports, ok := svc.UDPPorts(); ok {
+		if err := appendPorts(&findings, t.GetName(), UDPPORTSOPEN, "Reachable UDP ports", ports); err != nil {
+			return nil, err
+		}
+	}
+
+	// LOCALPROBESTATUS — always, including on failure. This is what tells a
+	// reader "could not measure" apart from "measured zero"; without it a
+	// silence is indistinguishable from a hardened sandbox.
+	sv, err := structpb.NewValue(svc.Status)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to convert local probe status to protobuf value")
+		return nil, err
+	}
+	findings = append(findings, &reportv1.Finding{
+		FindingType: LOCALPROBESTATUS,
+		Task:        t.GetName(),
+		Description: "How the local service measurement went",
+		Value:       sv,
+	})
 
 	log.Info().Str("task", t.GetName()).Msg("Network scanning task completed successfully")
 	return findings, nil
+}
+
+func appendPorts(findings *[]*reportv1.Finding, task, ft, desc string, ports []int) error {
+	v, err := structpb.NewValue(intSliceToInterface(ports))
+	if err != nil {
+		log.Error().Err(err).Str("finding", ft).Msg("Failed to convert ports to protobuf value")
+		return err
+	}
+	*findings = append(*findings, &reportv1.Finding{
+		FindingType: ft, Task: task, Description: desc, Value: v,
+	})
+	return nil
 }
 
 // ProxyTask produces: PROXYDETECTION

--- a/pkg/tasks/baseline/errno_other.go
+++ b/pkg/tasks/baseline/errno_other.go
@@ -1,0 +1,73 @@
+//go:build !windows
+// +build !windows
+
+package tasks
+
+import "syscall"
+
+// POSIX errno predicates. These exist as a platform-split pair with
+// errno_windows.go for one reason: Windows returns Winsock numbers, and the
+// syscall.E* constants there are Go-synthesised values the socket layer never
+// produces. Keeping the comparison behind these helpers is what stops shared
+// code compiling cleanly and being wrong at runtime on one platform.
+
+func isRefused(e syscall.Errno) bool { return e == syscall.ECONNREFUSED }
+
+func isPermission(e syscall.Errno) bool {
+	return e == syscall.EPERM || e == syscall.EACCES
+}
+
+func isUnreachable(e syscall.Errno) bool {
+	return e == syscall.ENETUNREACH || e == syscall.EHOSTUNREACH ||
+		e == syscall.ENETDOWN || e == syscall.EHOSTDOWN
+}
+
+// isResourceExhaustion is the class the old scanner silently turned into a
+// security finding. Running out of file descriptors is a fact about the probe,
+// never about the sandbox.
+func isResourceExhaustion(e syscall.Errno) bool {
+	return e == syscall.EMFILE || e == syscall.ENFILE ||
+		e == syscall.ENOBUFS || e == syscall.ENOMEM ||
+		e == syscall.EADDRNOTAVAIL
+}
+
+func isTimeout(e syscall.Errno) bool { return e == syscall.ETIMEDOUT }
+
+func errnoName(e syscall.Errno) string {
+	switch e {
+	case syscall.ECONNREFUSED:
+		return "ECONNREFUSED"
+	case syscall.EPERM:
+		return "EPERM"
+	case syscall.EACCES:
+		return "EACCES"
+	case syscall.ENETUNREACH:
+		return "ENETUNREACH"
+	case syscall.EHOSTUNREACH:
+		return "EHOSTUNREACH"
+	case syscall.ENETDOWN:
+		return "ENETDOWN"
+	case syscall.EHOSTDOWN:
+		return "EHOSTDOWN"
+	case syscall.EMFILE:
+		return "EMFILE"
+	case syscall.ENFILE:
+		return "ENFILE"
+	case syscall.ENOBUFS:
+		return "ENOBUFS"
+	case syscall.ENOMEM:
+		return "ENOMEM"
+	case syscall.EADDRNOTAVAIL:
+		return "EADDRNOTAVAIL"
+	case syscall.ETIMEDOUT:
+		return "ETIMEDOUT"
+	case syscall.ECONNRESET:
+		return "ECONNRESET"
+	}
+	return e.Error()
+}
+
+// enableUDPErrorReporting is a no-op off Windows. A connected UDP socket
+// surfaces ICMP port-unreachable as ECONNREFUSED on the next operation without
+// anything being asked of it.
+func enableUDPErrorReporting(any) error { return nil }

--- a/pkg/tasks/baseline/errno_windows.go
+++ b/pkg/tasks/baseline/errno_windows.go
@@ -1,0 +1,116 @@
+//go:build windows
+// +build windows
+
+package tasks
+
+import (
+	"net"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Winsock error numbers, not the syscall.E* constants.
+//
+// This file exists because of a trap that compiles cleanly and is always
+// wrong: on Windows, syscall.ECONNREFUSED is defined as APPLICATION_ERROR+n, a
+// Go-synthesised value the socket layer never returns. Winsock returns
+// WSAECONNREFUSED (10061). So errors.Is(err, syscall.ECONNREFUSED) builds
+// happily on Windows and silently never matches, which would classify every
+// refusal as an unknown error.
+
+func isRefused(e syscall.Errno) bool {
+	// WSAECONNRESET is how a connected UDP socket surfaces an ICMP
+	// port-unreachable, so it belongs here alongside the TCP refusal.
+	return e == syscall.Errno(windows.WSAECONNREFUSED) ||
+		e == syscall.Errno(windows.WSAECONNRESET)
+}
+
+func isPermission(e syscall.Errno) bool {
+	return e == syscall.Errno(windows.WSAEACCES)
+}
+
+func isUnreachable(e syscall.Errno) bool {
+	return e == syscall.Errno(windows.WSAENETUNREACH) ||
+		e == syscall.Errno(windows.WSAEHOSTUNREACH) ||
+		e == syscall.Errno(windows.WSAENETDOWN)
+}
+
+// isResourceExhaustion is the class the old scanner silently turned into a
+// security finding. Running out of sockets is a fact about the probe, never
+// about the sandbox.
+func isResourceExhaustion(e syscall.Errno) bool {
+	return e == syscall.Errno(windows.WSAEMFILE) ||
+		e == syscall.Errno(windows.WSAENOBUFS) ||
+		e == syscall.Errno(windows.WSAEADDRNOTAVAIL)
+}
+
+func isTimeout(e syscall.Errno) bool {
+	return e == syscall.Errno(windows.WSAETIMEDOUT)
+}
+
+func errnoName(e syscall.Errno) string {
+	switch e {
+	case syscall.Errno(windows.WSAECONNREFUSED):
+		return "WSAECONNREFUSED"
+	case syscall.Errno(windows.WSAECONNRESET):
+		return "WSAECONNRESET"
+	case syscall.Errno(windows.WSAEACCES):
+		return "WSAEACCES"
+	case syscall.Errno(windows.WSAENETUNREACH):
+		return "WSAENETUNREACH"
+	case syscall.Errno(windows.WSAEHOSTUNREACH):
+		return "WSAEHOSTUNREACH"
+	case syscall.Errno(windows.WSAENETDOWN):
+		return "WSAENETDOWN"
+	case syscall.Errno(windows.WSAEMFILE):
+		return "WSAEMFILE"
+	case syscall.Errno(windows.WSAENOBUFS):
+		return "WSAENOBUFS"
+	case syscall.Errno(windows.WSAEADDRNOTAVAIL):
+		return "WSAEADDRNOTAVAIL"
+	case syscall.Errno(windows.WSAETIMEDOUT):
+		return "WSAETIMEDOUT"
+	}
+	return e.Error()
+}
+
+// enableUDPErrorReporting re-enables ICMP error delivery on a connected UDP
+// socket.
+//
+// Go's own net package disables it on every UDP socket it creates
+// (net/fd_windows.go calls WSAIoctl with SIO_UDP_CONNRESET set to false),
+// because a stray ICMP port-unreachable otherwise fails an unrelated recv on a
+// shared socket. That is sensible for a general-purpose library and fatal for
+// a probe: it suppresses the single signal that distinguishes "nothing is
+// listening there" from "no answer came back", which is the whole basis of UDP
+// reachability.
+//
+// Turning it back on is therefore deliberate and scoped to sockets this probe
+// creates for one connected conversation each.
+func enableUDPErrorReporting(c any) error {
+	conn, ok := c.(*net.UDPConn)
+	if !ok {
+		return nil
+	}
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var ioctlErr error
+	if err := raw.Control(func(fd uintptr) {
+		flag := uint32(1) // TRUE: report ICMP errors on this socket
+		var ret uint32
+		ioctlErr = windows.WSAIoctl(
+			windows.Handle(fd),
+			windows.SIO_UDP_CONNRESET,
+			(*byte)(unsafe.Pointer(&flag)), uint32(unsafe.Sizeof(flag)),
+			nil, 0,
+			&ret, nil, 0,
+		)
+	}); err != nil {
+		return err
+	}
+	return ioctlErr
+}

--- a/pkg/tasks/baseline/listeners_darwin.go
+++ b/pkg/tasks/baseline/listeners_darwin.go
@@ -128,3 +128,6 @@ func inpcbListener(rec []byte, proto string) (Listener, bool) {
 // networkNamespace has no macOS equivalent. Returning "" says so, rather than
 // implying an unnamespaced host.
 func networkNamespace() string { return "" }
+
+// inventorySource names where the table came from, for the report.
+func inventorySource() string { return "sysctl-pcblist" }

--- a/pkg/tasks/baseline/listeners_linux.go
+++ b/pkg/tasks/baseline/listeners_linux.go
@@ -122,3 +122,6 @@ func networkNamespace() string {
 	}
 	return ns
 }
+
+// inventorySource names where the table came from, for the report.
+func inventorySource() string { return "procfs" }

--- a/pkg/tasks/baseline/listeners_other.go
+++ b/pkg/tasks/baseline/listeners_other.go
@@ -15,3 +15,6 @@ func listLocalListeners() ([]Listener, error) { return nil, errUnsupportedInvent
 
 // networkNamespace is Linux-only. Elsewhere there is nothing to name.
 func networkNamespace() string { return "" }
+
+// inventorySource names where the table came from, for the report.
+func inventorySource() string { return "unsupported" }

--- a/pkg/tasks/baseline/listeners_windows.go
+++ b/pkg/tasks/baseline/listeners_windows.go
@@ -199,3 +199,6 @@ func extendedTable(proc *windows.LazyProc, name string, family, class uint32) ([
 // networkNamespace has no Windows equivalent that means what the Linux one
 // means. Returning "" says so rather than implying a shared host network.
 func networkNamespace() string { return "" }
+
+// inventorySource names where the table came from, for the report.
+func inventorySource() string { return "iphlpapi" }

--- a/pkg/tasks/baseline/localsvc.go
+++ b/pkg/tasks/baseline/localsvc.go
@@ -1,0 +1,278 @@
+package tasks
+
+import (
+	"net"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	// probeDeadline is per attempt. Generous for loopback, where anything
+	// alive answers in microseconds, and short enough that a whole pass
+	// over a few dozen endpoints stays well under a second.
+	probeDeadline = 500 * time.Millisecond
+	// probeWorkers is deliberately small. The scanner this replaces used
+	// 66,535 goroutines, each holding a file descriptor with a 3s deadline,
+	// which is how a scan of localhost managed to exhaust the process's own
+	// fd limit and then report the resulting failures as a sandbox blocking
+	// things.
+	probeWorkers = 16
+)
+
+// LocalServices is the whole local-services measurement: ask the kernel what
+// is listening, prove the feedback channel works, then attempt each endpoint
+// and classify what came back.
+//
+// The two halves answer different questions and must not be conflated. The
+// inventory says what EXISTS in this network namespace. The attempts say what
+// this process can REACH. Under a Seatbelt profile denying network the first is
+// a full list and the second is empty; inside a network namespace the first is
+// empty and nothing is denied at all. Reporting only one of them cannot tell
+// those apart.
+type LocalServices struct {
+	Listeners []Listener
+	Results   []PortResult
+	Status    map[string]any
+}
+
+// MeasureLocalServices runs the measurement. It returns a result in every case,
+// including total failure: a caller that emits nothing when it is unsure
+// reproduces the bug this replaces, because a missing finding is scored as
+// "the sandbox blocked it".
+func MeasureLocalServices() LocalServices {
+	out := LocalServices{Status: map[string]any{
+		"method": "kernel-inventory-v1",
+		"source": inventorySource(),
+	}}
+	if ns := networkNamespace(); ns != "" {
+		out.Status["netns"] = ns
+	}
+
+	listeners, err := ListLocalListeners()
+	switch {
+	case err != nil && ErrUnsupportedInventory(err):
+		out.Status["table"] = "unsupported"
+		out.Status["error"] = err.Error()
+		return out
+	case err != nil:
+		// Could not read the table. That is not an empty table, and the
+		// difference is the whole point.
+		out.Status["table"] = "denied"
+		out.Status["error"] = err.Error()
+		return out
+	}
+	out.Status["table"] = "read"
+	out.Status["listeners_found"] = len(listeners)
+	out.Listeners = listeners
+
+	// Calibrate BEFORE probing anything real. A UDP timeout is meaningless
+	// until the negative-feedback channel is known to work, and the control
+	// must run first: probing real endpoints first would consume the ICMP
+	// rate-limit budget and make the control look dead.
+	//
+	// The kernel inventory is what makes this trustworthy. The old sweep
+	// fired at 65,535 closed ports and drained that budget every time, so a
+	// control probe could never have been believed. Here the probe set is a
+	// few dozen endpoints, so there is almost nothing to drain.
+	cal := calibrate()
+	out.Status["control_tcp"] = string(cal.tcp)
+	out.Status["control_udp"] = string(cal.udp)
+	out.Status["udp_feedback"] = cal.feedback()
+
+	out.Results = probeAll(listeners)
+	out.Status["results"] = out.Results
+	return out
+}
+
+// TCPPorts returns the TCP ports this process reached, and whether the
+// measurement concluded at all. A false second return means the caller must
+// emit no finding: the site reads an absent finding as unmeasured, and an
+// empty one as a measured negative, so publishing [] here would claim a
+// sandbox blocked something that was never tested.
+func (s LocalServices) TCPPorts() ([]int, bool) {
+	if s.Status["table"] != "read" {
+		return nil, false
+	}
+	return reachablePorts(s.Results, "tcp"), true
+}
+
+// UDPPorts is the same for UDP, with one extra condition: silence only counts
+// as reachable when the control proved the refusal channel works.
+//
+//	working     a bound port that stays quiet was reached; the service
+//	            simply had nothing to say to an empty datagram
+//	suppressed  ICMP is being dropped, so only an actual reply counts
+//	unknown     nothing can be concluded from silence at all, so nothing
+//	            is reported
+//
+// The "unknown" branch is the one that matters. A sandbox dropping everything
+// uniformly gives silence on both controls; reporting [] there would read as
+// "measured, nothing reachable", when in truth nothing was measured.
+func (s LocalServices) UDPPorts() ([]int, bool) {
+	if s.Status["table"] != "read" {
+		return nil, false
+	}
+	switch s.Status["udp_feedback"] {
+	case "working":
+		seen := map[int]struct{}{}
+		out := []int{}
+		for _, r := range s.Results {
+			if r.Proto != "udp" {
+				continue
+			}
+			if r.Outcome != OutcomeReachable && r.Outcome != OutcomeSilent {
+				continue
+			}
+			if _, dup := seen[r.Port]; dup {
+				continue
+			}
+			seen[r.Port] = struct{}{}
+			out = append(out, r.Port)
+		}
+		sortInts(out)
+		return out, true
+	case "suppressed":
+		return reachablePorts(s.Results, "udp"), true
+	default:
+		return nil, false
+	}
+}
+
+// control is what an endpoint that is known NOT to be listening returns, which
+// is what makes every other outcome interpretable.
+type control struct{ tcp, udp Outcome }
+
+// feedback says whether a UDP silence can be read as "reachable but quiet".
+//
+//	working  a refusal came back, so the channel is live
+//	suppressed  TCP refused but UDP did not, so ICMP is being dropped
+//	unknown  neither refused: nothing can be concluded from UDP silence
+//
+// The "unknown" case is the one that matters and is easy to get wrong. A
+// sandbox that drops everything uniformly gives silence on both controls.
+// Reporting an empty port list there would say "measured nothing reachable",
+// which reads as a blocked capability. Nothing was measured at all.
+func (c control) feedback() string {
+	switch {
+	case c.udp == OutcomeRefused:
+		return "working"
+	case c.tcp == OutcomeRefused:
+		return "suppressed"
+	default:
+		return "unknown"
+	}
+}
+
+func calibrate() control {
+	port, ok := freeLoopbackPort()
+	if !ok {
+		return control{tcp: OutcomeProbeError, udp: OutcomeProbeError}
+	}
+	t, _, _ := attempt("tcp", "127.0.0.1", port)
+	u, _, _ := attempt("udp", "127.0.0.1", port)
+	return control{tcp: t, udp: u}
+}
+
+// freeLoopbackPort asks the kernel for a port and immediately gives it back, so
+// the number is known to be unbound. If binding is denied — which is exactly
+// what a tight sandbox does — there is no control to run.
+func freeLoopbackPort() (int, bool) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, false
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if err := l.Close(); err != nil {
+		return 0, false
+	}
+	return port, true
+}
+
+func probeAll(ls []Listener) []PortResult {
+	jobs := make(chan Listener)
+	results := make(chan PortResult, len(ls))
+	var wg sync.WaitGroup
+	for i := 0; i < probeWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for l := range jobs {
+				o, call, errno := attempt(l.Proto, dialAddr(l), l.Port)
+				results <- PortResult{
+					Proto: l.Proto, Addr: dialAddr(l), Port: l.Port,
+					Outcome: o, Syscall: call, Errno: errno,
+				}
+			}
+		}()
+	}
+	go func() {
+		for _, l := range ls {
+			jobs <- l
+		}
+		close(jobs)
+	}()
+	go func() { wg.Wait(); close(results) }()
+
+	out := make([]PortResult, 0, len(ls))
+	for r := range results {
+		out = append(out, r)
+	}
+	return out
+}
+
+// dialAddr picks what to actually connect to. A wildcard bind is reachable on
+// loopback; a bind to one address has to be dialled at that address.
+//
+// Never the name "localhost": resolving it can yield ::1 or 127.0.0.1 in either
+// order, and a probe that silently dialled a different family than the one the
+// service is bound to is a strong candidate for the intermittent misses in the
+// published series.
+func dialAddr(l Listener) string {
+	if l.Addr == "" {
+		return "127.0.0.1"
+	}
+	return l.Addr
+}
+
+// attempt makes one connection and classifies the result.
+//
+// For UDP a connected socket is required: an unconnected one never surfaces
+// ICMP errors at all. Connect, write, then read with a deadline — the refusal
+// arrives on the read, not the write.
+func attempt(proto, host string, port int) (Outcome, string, string) {
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	conn, err := net.DialTimeout(proto, addr, probeDeadline)
+	if err != nil {
+		return classify(err)
+	}
+	defer conn.Close()
+
+	if proto != "udp" {
+		return OutcomeReachable, "", ""
+	}
+
+	// Windows suppresses ICMP errors on UDP sockets by default; ask for them
+	// back. If that fails the socket still works, but its silence carries no
+	// information, which the status already records.
+	_ = enableUDPErrorReporting(conn)
+
+	if _, err := conn.Write([]byte{}); err != nil {
+		return classify(err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(probeDeadline)); err != nil {
+		return classify(err)
+	}
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err != nil {
+		o, call, errno := classify(err)
+		if o == OutcomeSilent {
+			// Silence on a socket the kernel says is bound. Whether
+			// that means reachable depends on the control, which the
+			// caller applies; on its own it is not evidence.
+			return OutcomeSilent, call, errno
+		}
+		return o, call, errno
+	}
+	return OutcomeReachable, "", ""
+}

--- a/pkg/tasks/baseline/localsvc.go
+++ b/pkg/tasks/baseline/localsvc.go
@@ -81,7 +81,24 @@ func MeasureLocalServices() LocalServices {
 	out.Status["udp_feedback"] = cal.feedback()
 
 	out.Results = probeAll(listeners)
-	out.Status["results"] = out.Results
+	// structpb only accepts the basic Go kinds, so the per-port detail goes
+	// in as plain maps rather than as []PortResult. Without this the whole
+	// status finding fails to serialise at runtime while building fine.
+	rows := make([]any, 0, len(out.Results))
+	for _, r := range out.Results {
+		row := map[string]any{
+			"proto": r.Proto, "addr": r.Addr,
+			"port": float64(r.Port), "outcome": string(r.Outcome),
+		}
+		if r.Syscall != "" {
+			row["syscall"] = r.Syscall
+		}
+		if r.Errno != "" {
+			row["errno"] = r.Errno
+		}
+		rows = append(rows, row)
+	}
+	out.Status["results"] = rows
 	return out
 }
 

--- a/pkg/tasks/baseline/network.go
+++ b/pkg/tasks/baseline/network.go
@@ -5,22 +5,12 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/controlplaneio/sandbox-probe/v6/pkg/models"
 	"github.com/rs/zerolog/log"
-)
-
-const (
-	startPort = 1
-	endPort   = 65535
-
-	timeout = 3000 * time.Millisecond
-	workers = 66535
 )
 
 func DnsQuery(name string) ([]net.IP, error) {
@@ -61,121 +51,8 @@ func GetProxy() (*models.ProxyConfig, error) {
 	return GetProxyFromEnv()
 }
 
-func ScanTCP(host string) []int {
-	ports := make(chan int, workers)
-	results := make(chan int, 1024)
-
-	var wg sync.WaitGroup
-
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for port := range ports {
-				address := networkAddress(host, port)
-				conn, err := net.DialTimeout("tcp", address, timeout)
-				if err == nil {
-					results <- port
-					conn.Close()
-				}
-			}
-		}()
-	}
-
-	go func() {
-		for port := startPort; port <= endPort; port++ {
-			ports <- port
-		}
-		close(ports)
-	}()
-
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	var openPorts []int
-	for port := range results {
-		openPorts = append(openPorts, port)
-	}
-
-	return openPorts
-}
-
-// TODO: this method is not the best to get UDP ports exposed
-// it fails for some ports that don't repond to empty queries
-// develop OS specific method in the future
-func ScanUDP(host string) []int {
-	// TODO: fix usage in darwin
-	// it reports all the ports because they all timeout
-	if runtime.GOOS == "darwin" {
-		return []int{}
-	}
-	ports := make(chan int, workers)
-	results := make(chan int, 1024)
-
-	var wg sync.WaitGroup
-
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for port := range ports {
-				address := networkAddress(host, port)
-
-				conn, err := net.DialTimeout("udp", address, timeout)
-				if err != nil {
-					continue
-				}
-
-				_, err = conn.Write([]byte{})
-				if err == nil {
-					_ = conn.SetReadDeadline(time.Now().Add(timeout))
-					buf := make([]byte, 1)
-					_, err = conn.Read(buf)
-
-					// responded OR silent → open|filtered
-					if err == nil || netErrTimeout(err) {
-						results <- port
-					}
-				}
-				conn.Close()
-			}
-		}()
-	}
-
-	go func() {
-		for port := startPort; port <= endPort; port++ {
-			ports <- port
-		}
-		close(ports)
-	}()
-
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	var openPorts []int
-	for port := range results {
-		openPorts = append(openPorts, port)
-	}
-
-	return openPorts
-}
-
 func networkAddress(host string, port int) string {
 	return net.JoinHostPort(host, strconv.Itoa(port))
-}
-
-func netErrTimeout(err error) bool {
-	if err == nil {
-		return false
-	}
-	if ne, ok := err.(net.Error); ok && ne.Timeout() {
-		return true
-	}
-	return false
 }
 
 func GetSockets(startPath string, fast bool) ([]string, error) {

--- a/pkg/tasks/baseline/network_test.go
+++ b/pkg/tasks/baseline/network_test.go
@@ -85,68 +85,6 @@ func TestGetProxy(t *testing.T) {
 	t.Logf("  PAC_URL:     %s", cfg.PACURL)
 }
 
-func Test_scanTCP(t *testing.T) {
-	// Test TCP port scanning on localhost
-	// Note: This scans all ports 1-65535 and may take some time
-	// In most environments, some ports will be open on localhost
-
-	t.Log("Starting TCP port scan on localhost (this may take a moment)...")
-	openPorts := ScanTCP("127.0.0.1")
-
-	// Should return a slice (even if empty)
-	assert.NotNil(t, openPorts, "scanTCP should return a non-nil slice")
-
-	// Log results
-	t.Logf("Found %d open TCP ports on localhost", len(openPorts))
-
-	if len(openPorts) > 0 {
-		// Log first few open ports for debugging
-		maxLog := 10
-		if len(openPorts) < maxLog {
-			maxLog = len(openPorts)
-		}
-
-		// Verify all ports are in valid range
-		for _, port := range openPorts {
-			assert.GreaterOrEqual(t, port, 1, "Port should be >= 1")
-			assert.LessOrEqual(t, port, 65535, "Port should be <= 65535")
-		}
-	} else {
-		t.Log("No open TCP ports found (this may indicate network isolation)")
-	}
-}
-
-func Test_scanUDP(t *testing.T) {
-	// Test UDP port scanning on localhost
-	// Note: UDP scanning is inherently unreliable as it depends on responses
-	// Many UDP services don't respond to empty packets, so results may vary
-
-	t.Log("Starting UDP port scan on localhost (this may take a moment)...")
-	openPorts := ScanUDP("127.0.0.1")
-
-	// Should return a slice (even if empty)
-	assert.NotNil(t, openPorts, "scanUDP should return a non-nil slice")
-
-	// Log results
-	t.Logf("Found %d open/filtered UDP ports on localhost", len(openPorts))
-
-	if len(openPorts) > 0 {
-		// Log first few open ports for debugging
-		maxLog := 10
-		if len(openPorts) < maxLog {
-			maxLog = len(openPorts)
-		}
-
-		// Verify all ports are in valid range
-		for _, port := range openPorts {
-			assert.GreaterOrEqual(t, port, 1, "Port should be >= 1")
-			assert.LessOrEqual(t, port, 65535, "Port should be <= 65535")
-		}
-	} else {
-		t.Log("No open/filtered UDP ports found (this is common as UDP scanning is unreliable)")
-	}
-}
-
 func Test_getSockets(t *testing.T) {
 	// Test getSockets function
 

--- a/pkg/tasks/baseline/reach.go
+++ b/pkg/tasks/baseline/reach.go
@@ -1,0 +1,149 @@
+package tasks
+
+import (
+	"errors"
+	"net"
+	"os"
+	"syscall"
+)
+
+// Outcome is what a single connection attempt established. The old scanner had
+// two states, open and not-open, and inferred "not-open" from silence — which
+// is how a scan that timed out under load became a report that a sandbox had
+// blocked something.
+//
+// These are outcomes of a MEASUREMENT, not verdicts about a sandbox. Only
+// OutcomeReachable is evidence of exposure. See scoring note below.
+type Outcome string
+
+const (
+	// OutcomeReachable: the connection completed. This is the only outcome
+	// that proves the process can reach the service.
+	OutcomeReachable Outcome = "reachable"
+
+	// OutcomeRefused: something answered with a refusal — a TCP RST, or an
+	// ICMP port-unreachable surfaced on a connected UDP socket.
+	//
+	// It is tempting to read this as "the packet got there, so nothing
+	// blocked it". Do not. A refusal is forgeable by the very thing being
+	// measured: iptables -j REJECT --reject-with tcp-reset synthesises an
+	// RST, and a seccomp-notify supervisor (which is how nono works) can
+	// return any errno it likes for connect(), including this one. So a
+	// refusal means "something refused", which may be the service being
+	// absent or may be policy wearing a disguise. Diagnostic only.
+	OutcomeRefused Outcome = "refused"
+
+	// OutcomeBlocked: policy rejected the attempt locally, before anything
+	// left. Seatbelt's (deny network*) and an iptables OUTPUT owner rule
+	// both surface here.
+	OutcomeBlocked Outcome = "blocked"
+
+	// OutcomeUnreachable: no route. Typical of a process in its own network
+	// namespace with no path to the target.
+	OutcomeUnreachable Outcome = "unreachable"
+
+	// OutcomeSilent: nothing came back before the deadline. Genuinely
+	// ambiguous — dropped, filtered, rate-limited, or merely slow. The old
+	// scanner recorded this as "open", which is backwards.
+	OutcomeSilent Outcome = "silent"
+
+	// OutcomeProbeError: the probe itself failed — out of file descriptors,
+	// no ephemeral ports left, out of buffers. Never a statement about the
+	// sandbox. The old scanner swallowed these, which is why the published
+	// corpus contains file-descriptor exhaustion rendered as "blocked".
+	OutcomeProbeError Outcome = "probe_error"
+)
+
+// PortResult is one attempt against one inventoried endpoint.
+type PortResult struct {
+	Proto   string  `json:"proto"`
+	Addr    string  `json:"addr"`
+	Port    int     `json:"port"`
+	Outcome Outcome `json:"outcome"`
+	// Syscall is which call failed — "connect" means nothing left this
+	// process, "read" means a datagram left and an answer came back. Free
+	// depth information that the errno alone does not carry.
+	Syscall string `json:"syscall,omitempty"`
+	Errno   string `json:"errno,omitempty"`
+}
+
+// classify turns a dial or read error into an outcome.
+//
+// Order matters: a timeout is the ABSENCE of an errno, so every specific errno
+// must be tested before falling through to the deadline case, or a refusal
+// carrying a deadline-ish wrapper would be misread as silence.
+func classify(err error) (Outcome, string, string) {
+	if err == nil {
+		return OutcomeReachable, "", ""
+	}
+
+	var se *os.SyscallError
+	call := ""
+	if errors.As(err, &se) {
+		call = se.Syscall
+	}
+
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		name := errnoName(errno)
+		switch {
+		case isRefused(errno):
+			return OutcomeRefused, call, name
+		case isPermission(errno):
+			return OutcomeBlocked, call, name
+		case isUnreachable(errno):
+			return OutcomeUnreachable, call, name
+		case isResourceExhaustion(errno):
+			return OutcomeProbeError, call, name
+		case isTimeout(errno):
+			return OutcomeSilent, call, name
+		}
+		// An errno we have no opinion on is not silence and is not a
+		// verdict. Say so rather than guessing.
+		return OutcomeProbeError, call, name
+	}
+
+	// No errno: a deadline, or a wrapped error with nothing underneath.
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return OutcomeSilent, call, "deadline"
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return OutcomeSilent, call, "timeout"
+	}
+	return OutcomeProbeError, call, ""
+}
+
+// reachablePorts is what the tcp_ports_open / udp_ports_open findings carry:
+// ports this process actually reached.
+//
+// ONLY OutcomeReachable counts. A refusal is excluded deliberately, even
+// though it proves a packet was answered, because the answer is forgeable by a
+// REJECT firewall or a seccomp-notify supervisor — so counting it would let a
+// sandbox that blocks everything by forging refusals read as exposure. The
+// refusals are still reported, in the per-port results, where they inform a
+// reader without scoring anything.
+func reachablePorts(rs []PortResult, proto string) []int {
+	seen := map[int]struct{}{}
+	out := []int{}
+	for _, r := range rs {
+		if r.Proto != proto || r.Outcome != OutcomeReachable {
+			continue
+		}
+		if _, dup := seen[r.Port]; dup {
+			continue
+		}
+		seen[r.Port] = struct{}{}
+		out = append(out, r.Port)
+	}
+	sortInts(out)
+	return out
+}
+
+func sortInts(a []int) {
+	for i := 1; i < len(a); i++ {
+		for j := i; j > 0 && a[j] < a[j-1]; j-- {
+			a[j], a[j-1] = a[j-1], a[j]
+		}
+	}
+}

--- a/pkg/tasks/baseline/reach_test.go
+++ b/pkg/tasks/baseline/reach_test.go
@@ -1,0 +1,217 @@
+package tasks
+
+import (
+	"errors"
+	"net"
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+// A real listener is reachable; a port nothing holds is refused. These are the
+// two anchors every other outcome is read against.
+func TestAttemptReachableAndRefused(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	if o, _, e := attempt("tcp", "127.0.0.1", port); o != OutcomeReachable {
+		t.Errorf("live listener: got %s (%s), want reachable", o, e)
+	}
+
+	free, ok := freeLoopbackPort()
+	if !ok {
+		t.Skip("could not obtain a known-free port")
+	}
+	o, _, e := attempt("tcp", "127.0.0.1", free)
+	if o != OutcomeRefused {
+		t.Errorf("unbound port: got %s (%s), want refused", o, e)
+	}
+}
+
+// The distinction the old scanner could not make. Both of these produce no
+// connection, and treating them the same is what turned a probe running out of
+// file descriptors into a report that a sandbox had blocked something.
+func TestClassifySeparatesPolicyFromResourceFromSilence(t *testing.T) {
+	wrap := func(e error) error {
+		return &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", e)}
+	}
+	cases := []struct {
+		name string
+		err  error
+		want Outcome
+	}{
+		{"nil is the only proof of reach", nil, OutcomeReachable},
+		{"resource exhaustion is never a verdict", wrap(syscall.EMFILE), OutcomeProbeError},
+		{"deadline is ambiguous, not open", wrap(os.ErrDeadlineExceeded), OutcomeSilent},
+	}
+	for _, c := range cases {
+		if got, _, _ := classify(c.err); got != c.want {
+			t.Errorf("%s: got %s, want %s", c.name, got, c.want)
+		}
+	}
+
+	// Platform-specific errnos, checked through the same helpers production
+	// uses. On Windows the syscall.E* constants are Go-synthesised values
+	// Winsock never returns, so comparing against them directly would
+	// compile and silently never match.
+	if runtime.GOOS != "windows" {
+		if got, _, _ := classify(wrap(syscall.EPERM)); got != OutcomeBlocked {
+			t.Errorf("EPERM: got %s, want blocked", got)
+		}
+		if got, _, _ := classify(wrap(syscall.ENETUNREACH)); got != OutcomeUnreachable {
+			t.Errorf("ENETUNREACH: got %s, want unreachable", got)
+		}
+		if got, _, _ := classify(wrap(syscall.ECONNREFUSED)); got != OutcomeRefused {
+			t.Errorf("ECONNREFUSED: got %s, want refused", got)
+		}
+	}
+}
+
+// classify must see through wrapping. net returns *net.OpError around
+// *os.SyscallError around syscall.Errno, and a type assertion at any one layer
+// breaks the moment another is added.
+func TestClassifyUnwrapsNestedErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX errno values are synthesised on Windows")
+	}
+	err := &net.OpError{Op: "dial", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}
+	o, call, name := classify(err)
+	if o != OutcomeRefused {
+		t.Errorf("got %s, want refused", o)
+	}
+	if call != "connect" {
+		t.Errorf("syscall = %q, want connect — it says how far the attempt got", call)
+	}
+	if name != "ECONNREFUSED" {
+		t.Errorf("errno name = %q, want ECONNREFUSED", name)
+	}
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		t.Error("sanity: the wrapped error should still match with errors.Is")
+	}
+}
+
+// Only a completed connection counts as exposure.
+//
+// A refusal proves something answered, but not that policy allowed it: an
+// iptables REJECT forges a TCP reset, and a seccomp-notify supervisor can
+// return any errno it chooses for connect(). Counting refusals as reach would
+// let a sandbox that blocks everything by forging refusals read as wide open.
+func TestOnlyReachableIsScored(t *testing.T) {
+	rs := []PortResult{
+		{Proto: "tcp", Port: 22, Outcome: OutcomeReachable},
+		{Proto: "tcp", Port: 80, Outcome: OutcomeRefused},
+		{Proto: "tcp", Port: 443, Outcome: OutcomeBlocked},
+		{Proto: "tcp", Port: 8080, Outcome: OutcomeSilent},
+		{Proto: "tcp", Port: 9090, Outcome: OutcomeProbeError},
+		{Proto: "udp", Port: 53, Outcome: OutcomeReachable},
+	}
+	got := reachablePorts(rs, "tcp")
+	if len(got) != 1 || got[0] != 22 {
+		t.Errorf("scored ports = %v, want [22]: only a completed connection is evidence", got)
+	}
+}
+
+// The branch that decides whether a UDP silence means anything.
+func TestUDPSilenceNeedsAProvenFeedbackChannel(t *testing.T) {
+	results := []PortResult{
+		{Proto: "udp", Port: 5353, Outcome: OutcomeSilent},
+		{Proto: "udp", Port: 123, Outcome: OutcomeReachable},
+	}
+	mk := func(feedback string) LocalServices {
+		return LocalServices{
+			Results: results,
+			Status:  map[string]any{"table": "read", "udp_feedback": feedback},
+		}
+	}
+
+	// Control refused: the channel is live, so a bound port that stays quiet
+	// was reached — the service just had nothing to say.
+	got, ok := mk("working").UDPPorts()
+	if !ok || len(got) != 2 {
+		t.Errorf("feedback working: got %v ok=%v, want both ports", got, ok)
+	}
+
+	// ICMP dropped: only an actual reply counts.
+	got, ok = mk("suppressed").UDPPorts()
+	if !ok || len(got) != 1 || got[0] != 123 {
+		t.Errorf("feedback suppressed: got %v ok=%v, want [123]", got, ok)
+	}
+
+	// Neither control refused. Nothing can be concluded, so nothing is
+	// reported — an empty list here would claim a measured negative that
+	// was never measured.
+	got, ok = mk("unknown").UDPPorts()
+	if ok {
+		t.Errorf("feedback unknown: got %v, want no finding emitted at all", got)
+	}
+}
+
+// A table that could not be read must not produce a finding either.
+func TestUnreadableTableEmitsNoPorts(t *testing.T) {
+	s := LocalServices{Status: map[string]any{"table": "denied", "udp_feedback": "working"}}
+	if _, ok := s.TCPPorts(); ok {
+		t.Error("a denied socket table must not yield a tcp finding")
+	}
+	if _, ok := s.UDPPorts(); ok {
+		t.Error("a denied socket table must not yield a udp finding")
+	}
+}
+
+// The control's whole job is to be interpretable.
+func TestControlFeedbackRules(t *testing.T) {
+	cases := []struct {
+		c    control
+		want string
+	}{
+		{control{tcp: OutcomeRefused, udp: OutcomeRefused}, "working"},
+		{control{tcp: OutcomeRefused, udp: OutcomeSilent}, "suppressed"},
+		{control{tcp: OutcomeSilent, udp: OutcomeSilent}, "unknown"},
+		{control{tcp: OutcomeBlocked, udp: OutcomeBlocked}, "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.c.feedback(); got != c.want {
+			t.Errorf("control{tcp:%s udp:%s} = %q, want %q", c.c.tcp, c.c.udp, got, c.want)
+		}
+	}
+}
+
+// End to end against this machine's own kernel: a listener we just bound must
+// be inventoried and then reached.
+func TestMeasureLocalServicesFindsAndReachesOurListener(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	s := MeasureLocalServices()
+	if s.Status["table"] == "unsupported" {
+		t.Skipf("no socket-table reader on %s", runtime.GOOS)
+	}
+	if s.Status["table"] != "read" {
+		t.Fatalf("table not read: %v", s.Status)
+	}
+
+	ports, ok := s.TCPPorts()
+	if !ok {
+		t.Fatal("a readable table must yield a tcp finding")
+	}
+	found := false
+	for _, p := range ports {
+		if p == port {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("our own listener on %d was inventoried but not reached; ports=%v", port, ports)
+	}
+	if s.Status["method"] != "kernel-inventory-v1" {
+		t.Errorf("method = %v, want the cutover marker", s.Status["method"])
+	}
+}

--- a/pkg/tasks/baseline/seed_pipes_test.go
+++ b/pkg/tasks/baseline/seed_pipes_test.go
@@ -6,28 +6,50 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
 
-// TestMain doubles as the decoy pipe server. seedPipe spawns os.Executable()
-// with `serve-pipe <name> <lifetime>` — the probe binary in production, this
-// test binary here — so the round trip below exercises the real spawn, the real
+// TestMain doubles as the decoy servers. Both seedPipe and seedPort spawn
+// os.Executable() with a subcommand — the probe binary in production, this test
+// binary here — so the round trips below exercise the real spawn, the real
 // server and the real termination rather than a stand-in for them.
 func TestMain(m *testing.M) {
-	if len(os.Args) == 4 && os.Args[1] == "serve-pipe" {
-		d, err := time.ParseDuration(os.Args[3])
-		if err == nil {
-			err = ServePipe(os.Args[2], d)
+	if len(os.Args) == 4 {
+		switch os.Args[1] {
+		case "serve-pipe":
+			exitAfter(func() error {
+				d, err := time.ParseDuration(os.Args[3])
+				if err != nil {
+					return err
+				}
+				return ServePipe(os.Args[2], d)
+			})
+		case "serve-port":
+			exitAfter(func() error {
+				port, err := strconv.Atoi(os.Args[2])
+				if err != nil {
+					return err
+				}
+				d, err := time.ParseDuration(os.Args[3])
+				if err != nil {
+					return err
+				}
+				return ServePort(port, d)
+			})
 		}
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-		os.Exit(0)
 	}
 	os.Exit(m.Run())
+}
+
+func exitAfter(run func() error) {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
 }
 
 // windowsOnly skips everything below off Windows: no other OS has a pipe

--- a/pkg/tasks/baseline/seed_port.go
+++ b/pkg/tasks/baseline/seed_port.go
@@ -1,0 +1,179 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+// A port decoy is a listening TCP socket planted on the host before a scan, so
+// that "this sandbox cannot reach local services" becomes provable rather than
+// assumed.
+//
+// Why it is needed at all: the only thing the matrix could previously compare
+// against was whatever the runner happened to be running. On GitHub's images
+// that is sshd on 22, which is an accident of the image rather than something
+// anyone controls — the Windows runner's set churns completely between runs,
+// macOS harness rows saw port 22 anywhere from one run in five to five in
+// five, and on a developer's laptop there is no sshd at all because Remote
+// Login is off by default. A decoy we plant ourselves is the same target on
+// every OS, in every row, on every machine. That is what parity means.
+//
+// It is bound on 0.0.0.0 rather than loopback deliberately. The probe then
+// attempts BOTH 127.0.0.1 and the host's own address, and the pair separates
+// two cases a single target cannot:
+//
+//	Docker's default bridge   refused on loopback, reachable on the host
+//	                          address — the container has its own loopback, so
+//	                          this is the classic loopback-isolation bypass
+//	Seatbelt allow-localhost  the exact inverse
+//
+// No third-party machine is contacted. The listener is ours, on this host.
+// decoyPortLifetime matches the process-decoy belt: the server exits on its own
+// regardless of whether cleanup runs, so a crashed run cannot leave a listener
+// behind indefinitely.
+var decoyPortLifetime = decoyProcessLifetime
+
+const (
+	// portServerStartTimeout is how long seeding waits for the spawned
+	// server to actually be listening. This is the one genuinely new piece
+	// of engineering next to serve-pipe: exec.Cmd.Start returns as soon as
+	// the process exists, which is BEFORE it has bound anything. A scan that
+	// raced ahead would find the port refused and record a decoy that was
+	// never planted as a sandbox blocking it — manufacturing exactly the
+	// false negative this work exists to remove.
+	portServerStartTimeout = 15 * time.Second
+)
+
+// seededPort is the cleanup record. The pid and its creation time together are
+// what make removal safe on a reused runner: a pid alone can have been recycled
+// onto somebody else's process by the time cleanup runs.
+type seededPort struct {
+	Port    int   `json:"port"`
+	PID     int   `json:"pid"`
+	Created int64 `json:"created"`
+}
+
+var errPortDecoyUnavailable = errors.New("no free port available for a decoy")
+
+// ServePort binds port on all interfaces and holds it for d, then exits.
+//
+// It accepts and immediately closes connections rather than leaving them
+// queued, so a probe's connect succeeds cleanly instead of sitting in the
+// backlog, and so a scan cannot exhaust the listen queue and see later
+// attempts fail for a reason that has nothing to do with policy.
+func ServePort(port int, d time.Duration) error {
+	ln, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", strconv.Itoa(port)))
+	if err != nil {
+		return fmt.Errorf("bind decoy port %d: %w", port, err)
+	}
+	defer ln.Close()
+
+	done := time.After(d)
+	go func() {
+		<-done
+		ln.Close() // unblocks Accept below
+	}()
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			return nil // listener closed: lifetime expired
+		}
+		c.Close()
+	}
+}
+
+// seedPort plants one decoy and returns its record.
+//
+// Soft-plant discipline, the same rule every other decoy kind follows: the port
+// is one the kernel has just confirmed is free, so nothing real is displaced. If
+// it cannot get one, that is one skipped entry rather than a failed run.
+func seedPort() (seededPort, error) {
+	port, err := freeDecoyPort()
+	if err != nil {
+		return seededPort{}, err
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return seededPort{}, err
+	}
+	cmd := exec.Command(exe, "serve-port", strconv.Itoa(port), decoyPortLifetime.String())
+	if err := cmd.Start(); err != nil {
+		return seededPort{}, fmt.Errorf("spawn decoy port server: %w", err)
+	}
+	pid := cmd.Process.Pid
+
+	// Wait for the bind BEFORE releasing the handle: a server that never came
+	// up has to be killed, and the handle is what kills it portably.
+	if err := waitForPort(port, portServerStartTimeout); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return seededPort{}, err
+	}
+
+	// Now detach. The server must outlive the seeding process, the same
+	// lifecycle the pipe and process decoys use, and Release rather than Wait
+	// leaves no zombie behind.
+	created, cErr := processCreated(pid)
+	if cErr != nil {
+		created = 0 // cleanup falls back to matching on the pid alone
+	}
+	_ = cmd.Process.Release()
+	return seededPort{Port: port, PID: pid, Created: created}, nil
+}
+
+// freeDecoyPort asks the kernel for an unused port and hands it straight back,
+// so the number is known free at the moment of asking. There is an unavoidable
+// window between releasing it and the server binding it; waitForPort is what
+// turns losing that race into an error rather than a phantom decoy.
+func freeDecoyPort() (int, error) {
+	l, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		return 0, errPortDecoyUnavailable
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if err := l.Close(); err != nil {
+		return 0, errPortDecoyUnavailable
+	}
+	return port, nil
+}
+
+// waitForPort blocks until something answers on the port, or the timeout. A
+// decoy the scan cannot see yet is a decoy that was never planted.
+func waitForPort(port int, timeout time.Duration) error {
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			c.Close()
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("decoy port %d did not start listening within %s", port, timeout)
+}
+
+// hostAddresses returns this host's non-loopback IPv4 addresses, which is what
+// the probe dials as the second target. Empty is a legitimate answer — a fully
+// isolated container has no such address — and the caller reports that rather
+// than inventing one.
+func hostAddresses() []string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, a := range addrs {
+		n, ok := a.(*net.IPNet)
+		if !ok || n.IP.IsLoopback() || n.IP.To4() == nil {
+			continue
+		}
+		out = append(out, n.IP.String())
+	}
+	return out
+}

--- a/pkg/tasks/baseline/seed_port_test.go
+++ b/pkg/tasks/baseline/seed_port_test.go
@@ -1,0 +1,143 @@
+package tasks
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// The decoy has to be listening by the time seedPort returns, and it has to be
+// visible to the kernel inventory, or the scan that follows records a decoy
+// that was never planted as a sandbox blocking it.
+//
+// This is the property serve-pipe does not need and serve-port does:
+// exec.Cmd.Start returns as soon as the process exists, which is before it has
+// bound anything.
+func TestServePortIsListeningBeforeSeedReturns(t *testing.T) {
+	d, err := seedPort()
+	if err != nil {
+		t.Skipf("could not plant a port decoy here: %v", err)
+	}
+	defer stopDecoy(t, d.PID)
+
+	if d.Port <= 0 {
+		t.Fatalf("seeded port is %d", d.Port)
+	}
+	if d.PID <= 0 {
+		t.Fatalf("seeded pid is %d", d.PID)
+	}
+
+	// Reachable immediately, with no retry: that is the whole point.
+	c, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(d.Port)), time.Second)
+	if err != nil {
+		t.Fatalf("decoy port %d not reachable the instant seeding returned: %v", d.Port, err)
+	}
+	c.Close()
+
+	// And the kernel inventory must see it, since that is what selects it as
+	// a probe target.
+	ls, err := ListLocalListeners()
+	if err != nil {
+		if ErrUnsupportedInventory(err) {
+			t.Skip("no socket-table reader on this platform")
+		}
+		t.Fatalf("inventory: %v", err)
+	}
+	found := false
+	for _, l := range ls {
+		if l.Proto == "tcp" && l.Port == d.Port {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("decoy port %d is listening but absent from the kernel inventory", d.Port)
+	}
+}
+
+// It binds the wildcard address, not loopback. That is what lets the probe
+// attempt both 127.0.0.1 and the host's own address, which is the pair that
+// separates Docker's loopback isolation from a Seatbelt allow-localhost policy.
+func TestServePortBindsWildcardNotJustLoopback(t *testing.T) {
+	d, err := seedPort()
+	if err != nil {
+		t.Skipf("could not plant a port decoy here: %v", err)
+	}
+	defer stopDecoy(t, d.PID)
+
+	ls, err := ListLocalListeners()
+	if err != nil {
+		if ErrUnsupportedInventory(err) {
+			t.Skip("no socket-table reader on this platform")
+		}
+		t.Fatalf("inventory: %v", err)
+	}
+	for _, l := range ls {
+		if l.Proto == "tcp" && l.Port == d.Port {
+			if l.Addr != "" {
+				t.Errorf("decoy bound to %q, want the wildcard: a loopback-only decoy "+
+					"cannot distinguish container loopback isolation from a policy block", l.Addr)
+			}
+			return
+		}
+	}
+	t.Skip("decoy not visible in the inventory on this platform")
+}
+
+// Soft-plant discipline: the port must be one the kernel says is free, so a
+// decoy never displaces something real.
+func TestFreeDecoyPortIsActuallyFree(t *testing.T) {
+	port, err := freeDecoyPort()
+	if err != nil {
+		t.Skipf("cannot obtain a port here: %v", err)
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", strconv.Itoa(port)))
+	if err != nil {
+		t.Fatalf("port %d was reported free but could not be bound: %v", port, err)
+	}
+	ln.Close()
+}
+
+// waitForPort must fail rather than hang when nothing ever binds, so a failed
+// plant is an error the caller can act on instead of a phantom decoy.
+func TestWaitForPortTimesOutOnNothing(t *testing.T) {
+	port, err := freeDecoyPort()
+	if err != nil {
+		t.Skipf("cannot obtain a port here: %v", err)
+	}
+	start := time.Now()
+	if err := waitForPort(port, 300*time.Millisecond); err == nil {
+		t.Error("waiting on a port nothing binds must fail")
+	}
+	if el := time.Since(start); el > 3*time.Second {
+		t.Errorf("waited %s, far past the timeout", el)
+	}
+}
+
+// hostAddresses is the second probe target. It may legitimately be empty in a
+// fully isolated container, which the caller reports rather than papering over.
+func TestHostAddressesAreNonLoopbackIPv4(t *testing.T) {
+	for _, a := range hostAddresses() {
+		ip := net.ParseIP(a)
+		if ip == nil {
+			t.Errorf("%q is not an IP", a)
+			continue
+		}
+		if ip.IsLoopback() {
+			t.Errorf("%s is loopback; the whole point is to dial a non-loopback address", a)
+		}
+		if ip.To4() == nil {
+			t.Errorf("%s is not IPv4", a)
+		}
+	}
+}
+
+func stopDecoy(t *testing.T, pid int) {
+	t.Helper()
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	_ = p.Kill()
+}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -43,6 +43,20 @@ const (
 	SANDBOXDETECTION          = "sandbox_detection"
 	ENVIRONMENTDETECTION      = "environment_detection"
 	ENVSECRETDETECTION        = "env_secret_detection"
+
+	// LOCALLISTENERS is the kernel's own socket table: what is bound in this
+	// network namespace, as "tcp 127.0.0.1:22" strings. It is an INVENTORY
+	// and is deliberately not a scored capability — under a Seatbelt profile
+	// denying network it is byte-identical inside and outside the sandbox,
+	// so treating it as exposure would mark every confined macOS row leaked.
+	LOCALLISTENERS = "local_listeners"
+
+	// LOCALPROBESTATUS says how the local-services measurement went: which
+	// table was read, whether the UDP feedback channel is live, the network
+	// namespace, and the per-port outcomes behind the scored integers.
+	// It is what makes "could not measure" distinguishable from "measured
+	// zero", which is the root of the false-blocked class of bug.
+	LOCALPROBESTATUS = "local_probe_status"
 )
 
 var expectedTypes = map[string]reflect.Type{


### PR DESCRIPTION
The reachability half, and the cutover. Stacked on #54 — review that first.

## The measurement, on this machine, both binaries, same moment

| | old sweep | new |
|---|---|---|
| `tcp_ports_open` | `[445, 53, 88]` | **28 ports** |
| `udp_ports_open` | **absent** | **13 ports** |
| wall time | 4.37s | 1.04s |

The sweep missed **25 of 28 open TCP ports on the very host it was scanning**, and every one of those misses renders as "blocked" against a baseline. Its output was also in goroutine-completion order, so two identical scans could differ and any consumer diffing them saw a change that had not happened.

## Six outcomes instead of two

The old scan had open and not-open, and inferred not-open from silence. That is backwards — silence is the ambiguous case, and the informative results were being discarded.

| Outcome | Means |
|---|---|
| `reachable` | the connection completed. **The only proof of exposure.** |
| `refused` | something answered with a refusal. Diagnostic, never scored. |
| `blocked` | policy rejected it locally. Seatbelt's `(deny network*)`, an iptables OUTPUT owner rule. |
| `unreachable` | no route. Typical of a process in its own netns. |
| `silent` | nothing came back. Genuinely ambiguous. |
| `probe_error` | the probe ran out of descriptors, ports or buffers. **Never a statement about the sandbox.** |

That last one is not pedantry. The old code swallowed dial errors, so the published corpus contains file-descriptor exhaustion rendered as "blocked".

**Refusals are deliberately not scored as reach**, though a refusal proves something answered. The answer is forgeable by the thing being measured: `iptables -j REJECT --reject-with tcp-reset` synthesises an RST, and a seccomp-notify supervisor — how `nono` works — can return any errno it likes for `connect()`. Counting refusals would let a sandbox that blocks everything by forging them read as wide open. They stay in the per-port results, informing a reader without scoring anything.

## UDP silence needs a proven feedback channel

A control probe against a known-unbound port runs **first** — before the real pass, which would otherwise drain the ICMP rate-limit budget and make the control look dead.

- `working` — a refusal came back; a bound port that stays quiet was reached.
- `suppressed` — ICMP is dropped; only an actual reply counts.
- `unknown` — neither control refused; **nothing can be concluded**, so no finding is emitted at all.

The `unknown` branch matters most. A sandbox dropping everything uniformly gives silence on both controls, and reporting `[]` there would claim a measured negative that was never measured.

The kernel inventory is what makes this trustworthy: the probe set is a few dozen endpoints, not 65,535 closed ports, so there is almost no ICMP budget to drain.

## Findings

`tcp_ports_open` and `udp_ports_open` keep their shape and meaning. They are now emitted **even when empty**, because a scan that ran and found nothing is a real negative. Two new types:

- **`local_listeners`** — the kernel's inventory. Deliberately **not** a scored capability: under a Seatbelt profile denying network it is byte-identical inside and outside the sandbox, so scoring it would mark every confined macOS row leaked, permanently.
- **`local_probe_status`** — always emitted, including on failure. The table read, the source, the netns, the control outcomes, the UDP verdict, and the per-port results behind the scored integers.

## Verified by running the real task, not just unit tests

| Platform | Result |
|---|---|
| macOS 15 arm64 | 43 listeners, 28 tcp, 13 udp, feedback working |
| Linux container | table read, 0 listeners, `tcp []` and `udp []` — the measured negative the old code could not express — netns recorded |
| Windows 11 arm64 | **as standard user `probeusr` at Medium integrity**: 38 listeners, 14 tcp, 20 udp, feedback **working** |

That Windows result settles an open question. Go disables ICMP error delivery on every UDP socket it creates (`net/fd_windows.go`, `SIO_UDP_CONNRESET` false), which is why the old Windows UDP output was scheduler noise — ports 1, 4, 5 and 7, and 16,594 of them in one test. Re-enabling it per socket restores the signal, so `udp_ports_open` means the same thing on all three platforms.

## CI does not run on this PR

`Unit Tests` triggers only on pull requests targeting `main`, and this one is stacked on #54. Merge #54 first, then this retargets to `main` and CI runs normally.

In the meantime I ran the equivalent by hand on all three platforms:

| Platform | Suite | Result |
|---|---|---|
| macOS 15 arm64 | `go test ./...` | all pass |
| Linux container | `go test -timeout 10m ./...` | only the two pre-existing root-in-container failures (`TestIsWritable`, `TestIsWritableDirectoryRequiresSearchPermission`). It is **two better than before**, because the two sweep tests that failed there went with the sweep. |
| Windows 11 arm64 | full `baseline` suite, **as standard user at Medium integrity** | `PASS` |

That Windows run is coverage CI does not have: the `windows-latest` leg runs elevated.

## Two notes from the Windows run, neither a code problem

- **Windows Defender quarantined the probe binary three times** before an exclusion was added, at exactly the push timestamps. An unsigned binary dropped on disk and executed immediately is precisely its heuristic. Worth knowing for the Windows matrix rows.
- `structpb` accepts only the basic Go kinds, so the per-port detail is built as plain maps. Without that the status finding builds fine and fails to serialise at runtime.

## Also

`errno_windows.go` exists for a trap that compiles cleanly and is always wrong: `syscall.ECONNREFUSED` on Windows is a Go-synthesised `APPLICATION_ERROR` value Winsock never returns, so `errors.Is` against it silently never matches.

The probe now dials explicit literal addresses, never the name `localhost` — resolving it yields `::1` or `127.0.0.1` in either order, and a probe silently dialling a different family than the service is bound to is a strong candidate for the intermittent misses in the published series.

Sixteen workers, not 66,535.

https://claude.ai/code/session_0144XqJRJS5Cnt2DLGwYRTSV
