### PR TITLE
fix(docs): correct the build command, add code scanning, repoint moved links

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,40 @@
+name: "Security Scanning"
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+# Inlined rather than `uses: chrisns/.github/...@main`: an organisation repository
+# should not depend on a personal one, and controlplaneio/.github publishes no
+# reusable workflows to point at instead. The sibling sandbox-probe-reports repo
+# carries the same file for the same reason; keep the two in step.
+jobs:
+  CodeQL:
+    name: CodeQL
+    if: github.event.repository.visibility == 'public'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 2
+      # `languages: go` rather than autodetect. This repository is Go and nothing
+      # else, and an autodetect that quietly resolves to no language produces a
+      # green run that scanned nothing — the failure mode this job exists to stop.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        continue-on-error: true
+        id: initcodeql
+        with:
+          languages: go
+      - name: Autobuild
+        if: steps.initcodeql.outcome == 'success'
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - name: Perform CodeQL Analysis
+        if: steps.initcodeql.outcome == 'success'
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ make build
 Released binaries are published on the [releases page](https://github.com/controlplaneio/sandbox-probe/releases); the module is also `go build`-able directly:
 
 ```bash
-go build -o bin/sandbox-probe github.com/controlplaneio/sandbox-probe
+go build -o bin/sandbox-probe github.com/controlplaneio/sandbox-probe/v6
 ```
 
 If you intend to run `sandbox-probe` inside a container, make sure it is built statically with standard library paths, or arrange for the relevant paths to be mounted in. This isn't usually an issue but can bite on non-glibc or non-FHS systems like Alpine, NixOS, or anything via Nix.

--- a/docs/research/linux-desktop-inventory-contribution.md
+++ b/docs/research/linux-desktop-inventory-contribution.md
@@ -1,7 +1,7 @@
 # Research: contributed real Linux desktop inventory
 
 For [ADR 0002](../adr/0002-seed-ipc-and-process-targets.md) and
-[the (closed) seed-ipc-targets map](../../.scratch/seed-ipc-targets/map.md).
+[the (closed) seed-ipc-targets map](https://github.com/controlplaneio/sandbox-probe-reports/blob/main/.scratch/seed-ipc-targets/map.md).
 A contributor sent a collection script + its own real output from their
 daily-driver Linux desktop, as a second, independent data source for the
 seed catalogue. Both reviewed before use.

--- a/docs/research/linux-dev-machine-footprint.md
+++ b/docs/research/linux-dev-machine-footprint.md
@@ -1,7 +1,7 @@
 # Linux dev-machine IPC/process footprint
 
-Research for [`issues/06-linux-dev-machine-footprint.md`](../../.scratch/seed-ipc-targets/issues/06-linux-dev-machine-footprint.md),
-feeding the [seed-ipc-targets catalogue ticket](../../.scratch/seed-ipc-targets/issues/09-populate-catalogue-and-registry.md).
+Research for [`issues/06-linux-dev-machine-footprint.md`](https://github.com/controlplaneio/sandbox-probe-reports/blob/main/.scratch/seed-ipc-targets/issues/06-linux-dev-machine-footprint.md),
+feeding the [seed-ipc-targets catalogue ticket](https://github.com/controlplaneio/sandbox-probe-reports/blob/main/.scratch/seed-ipc-targets/issues/09-populate-catalogue-and-registry.md).
 Companion to the macOS data already gathered (see the map's Notes): Docker
 Desktop's `vmnetd` socket, three VS Code git-integration sockets, four
 `ssh-askpass` GUI-prompt sockets, two browsers' singleton sockets, and an AI

--- a/docs/research/namespace-parity-semantics.md
+++ b/docs/research/namespace-parity-semantics.md
@@ -1,6 +1,6 @@
 # Research: does a sandbox's "can't see the host socket" mean anything?
 
-Source ticket: `.scratch/seed-ipc-targets/issues/08-namespace-parity-semantics.md`
+Source ticket: [`.scratch/seed-ipc-targets/issues/08-namespace-parity-semantics.md`](https://github.com/controlplaneio/sandbox-probe-reports/blob/main/.scratch/seed-ipc-targets/issues/08-namespace-parity-semantics.md) in `sandbox-probe-reports`
 
 ## Question
 

--- a/docs/research/windows-dev-machine-footprint.md
+++ b/docs/research/windows-dev-machine-footprint.md
@@ -1,6 +1,6 @@
 # Research: Windows developer-machine named-pipe/process footprint
 
-For [wayfinder ticket 07](../../.scratch/seed-ipc-targets/issues/07-windows-dev-machine-footprint-capture.md).
+For [wayfinder ticket 07](https://github.com/controlplaneio/sandbox-probe-reports/blob/main/.scratch/seed-ipc-targets/issues/07-windows-dev-machine-footprint-capture.md).
 Captured against the `Win11.utm` VM (Windows 11 24H2, build 26100.4875) via
 `utmctl exec`/`utmctl file` — the QEMU guest agent, once installed inside
 the guest, turned this from a fully-manual task into something drivable
@@ -128,7 +128,7 @@ future session wants Docker Desktop / VS Code footprints for real:
 
 ## Consequence for the catalogue ticket
 
-[Ticket 09](../../.scratch/seed-ipc-targets/issues/09-populate-catalogue-and-registry.md)
+[Ticket 09](https://github.com/controlplaneio/sandbox-probe-reports/blob/main/.scratch/seed-ipc-targets/issues/09-populate-catalogue-and-registry.md)
 gets one fully-empirical, high-confidence Windows entry (`ssh-agent` →
 `\\.\pipe\openssh-ssh-agent`) and two documented-but-unverified leads
 (Docker Desktop, VS Code) that should be labeled with that distinction in

--- a/docs/research/windows-named-pipe-enumeration.md
+++ b/docs/research/windows-named-pipe-enumeration.md
@@ -1,6 +1,13 @@
 # Research: enumerating Windows named pipes from Go
 
-For [wayfinder ticket 04](../../.scratch/seed-ipc-targets/issues/04-windows-named-pipe-enumeration.md).
+> **This document corrects [ADR 0002](../adr/0002-seed-ipc-and-process-targets.md), per ticket #50.**
+> ADR 0002 claimed no Win32 API could enumerate the pipe namespace and that a new
+> `ntdll` dependency was needed. That is wrong. A plain `FindFirstFileW` loop over
+> `\\.\pipe\*` works unelevated, with nothing added — 57 pipe names on a real
+> Windows 11 host as an ordinary standard user. ADR 0002 carries the same
+> correction inline rather than deleting the original text.
+
+For [wayfinder ticket 04](https://github.com/controlplaneio/sandbox-probe-reports/blob/main/.scratch/seed-ipc-targets/issues/04-windows-named-pipe-enumeration.md).
 No existing `docs/research/` convention in this repo — establishing one here;
 future research notes should land alongside this file.
 
@@ -88,7 +95,7 @@ default per the Win32 docs above, which is consistent with unprivileged
 enumeration being the norm, though this is inference from absence of a
 documented restriction rather than an explicit "no admin needed" statement —
 worth confirming empirically once code exists, ideally in
-[the Windows dev-machine footprint capture ticket](../../.scratch/seed-ipc-targets/issues/07-windows-dev-machine-footprint-capture.md).
+[the Windows dev-machine footprint capture ticket](https://github.com/controlplaneio/sandbox-probe-reports/blob/main/.scratch/seed-ipc-targets/issues/07-windows-dev-machine-footprint-capture.md).
 
 ## 3. Shape of the equivalent to `DefaultSocketRoots`/`ScanSocketRoots`
 


### PR DESCRIPTION
Three things the migration left behind on this repository. Found by an audit of the migration plan against actual state.

## The README's own build command does not work

```
go build -o bin/sandbox-probe github.com/controlplaneio/sandbox-probe
```

No `/v6`. Inside a clone of this repository that fails outright:

```
no required module provides package github.com/controlplaneio/sandbox-probe
```

Run outside a module it is worse than an error. It resolves through the proxy to **`v1.1.0` from 18 May**, three months stale, and builds successfully. This is the exact defect the move to `/v6` existed to fix, surviving in the document that tells people how to build it.

## This repository has never had code scanning

No `security.yml`, and `code-scanning/analyses` returns 404. The sibling `sandbox-probe-reports` repo carries an inlined CodeQL workflow. The migration gave code scanning to the shell-and-JavaScript repository and left the Go product — which ships a binary through goreleaser — without any.

The same file is added here, at the same pinned action SHAs, with one deliberate difference: `languages: go` is set explicitly rather than left to autodetect. An autodetect that resolves to no language produces a green run that scanned nothing, which is the failure this job exists to prevent.

## Eight links point at a tree that is not here

The five research documents under `docs/research/` carry relative links into `../../.scratch/seed-ipc-targets/`. That tree is not in this repository.

It was never deleted. The split moved it to `sandbox-probe-reports`, where all ten `seed-ipc-targets` tickets and the map still are. The links now point there.

`windows-named-pipe-enumeration.md` also gains a header saying what it is. It is the document that corrects ADR 0002's claim that pipe enumeration needed an `ntdll` dependency, and it said nothing about that. ADR 0002 has carried the correction inline since ticket #50; the research note it corrects did not reference it.

## Checked

`go build ./...` and `go test ./...` pass. The corrected build command produces a binary; the documented one does not.
