### PR TITLE
feat(windows): detect the sandbox, and measure pipe reachability instead of visibility

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -134,7 +134,15 @@ add. Integrity level is not a signal either: measured High both inside and
 outside. Do not "improve" this detector by adding the group or privilege
 checks.
 
-The user-namespace rule (a non-identity uid_map) is the **last resort** in the
-wrapper-name chain, tried only after every more specific runtime detector has
-had its chance to claim the run — a new detector belongs *above* it, not
-below.
+The wrapper-name chain has two tiers, and a new detector belongs in whichever
+one matches what it can actually claim.
+
+- A detector that **names a tool** goes in the specific tier, above the
+  user-namespace rule. That rule (a non-identity uid_map) is the last resort
+  *for naming*, tried only after every more specific runtime detector has had
+  its chance to claim the run.
+- A detector that proves **enforcement exists but cannot name it** goes in the
+  generic-fallback tier at the very bottom, alongside no-new-privs and the
+  Windows restricted-token check, and returns `RuntimeUnknown`. Placing it
+  higher would let it outrank a detector that *can* name the tool, which is a
+  worse answer, not a better one.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,7 +71,19 @@ never an adopted one — so the process scan has something of the host's to find
 A `pipe` decoy is a Windows named pipe served under its real catalogue name by a
 probe process the seeder spawned; a pipe exists only while a server holds it
 open, so the server is the decoy, and a name a real service already serves is
-skipped rather than shadowed.
+skipped rather than shadowed. The server answers clients rather than merely
+holding the name — it writes the pipe's own name back and recycles the instance
+— because reachability is measured by a round trip through it.
+
+One pipe decoy is **not** a catalogue entry: `ReachPipeName`, the reachability
+instrument, plus a per-pid control name nothing ever serves. Reachability is only
+ever measured against those two, never a catalogue name. Opening a real service's
+pipe is not passive — it consumes a server instance and delivers a connection
+event — and at scan time a catalogue name is either our decoy or the real service,
+with no way to tell from a different process. That makes them the same precedent
+as `calibrate()`'s control port: an instrument the probe plants for itself, absent
+from the catalogue and absent from `SeedResult`'s tally, which counts the caller's
+targets only.
 
 ### Belt and suspenders
 The lifecycle of a decoy that has to stay alive during the scan (a `process` or

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -106,10 +106,21 @@ must know which one it is contributing to:
   ancestry, markers and, as a last resort, a restricted user namespace's ID
   map. Treat it as a hypothesis, not an attested fact.
 - A **mechanism** (`seccomp-filter`, `no-new-privs`, `landlock`,
-  `user-namespace`, …) is *kernel-attested*: read directly off a kernel
-  interface (`/proc/self/status`, the uid_map), true regardless of whether the
-  wrapper name resolved. Mechanisms are emitted alongside the badge, never
-  folded into it.
+  `user-namespace`, `restricted-token`, …) is *kernel-attested*: read directly
+  off a kernel interface (`/proc/self/status`, the uid_map, `IsTokenRestricted`
+  on Windows), true regardless of whether the wrapper name resolved. Mechanisms
+  are emitted alongside the badge, never folded into it.
+
+`restricted-token` is the Windows mechanism, and it is deliberately the *only*
+Windows signal. Measured against Codex CLI 0.149.1, a sandboxed process has
+`BUILTIN\Administrators` demoted to "use for deny only" and every privilege but
+`SeChangeNotifyPrivilege` stripped — and so does an ordinary non-elevated
+administrator's UAC split token, which is every Windows desktop. Detecting
+either of those would report the unconfined baseline as sandboxed.
+`IsTokenRestricted` looks for restricting SIDs, which UAC filtering does not
+add. Integrity level is not a signal either: measured High both inside and
+outside. Do not "improve" this detector by adding the group or privilege
+checks.
 
 The user-namespace rule (a non-identity uid_map) is the **last resort** in the
 wrapper-name chain, tried only after every more specific runtime detector has

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Each row below is a `finding_type` string you will see in `report.json`, what it
 | `hostname_detection` | system hostname | "Does the sandbox leak the host identity?" |
 | `env_secret_detection` | environment variables whose value is secret-shaped, by name and why they matched (never the value) | "Which credentials were handed to the agent's process in the first place?" |
 | `environment_detection` | host kernel release/version + OS release | "Which kernel/OS produced this result?" (so reports stay comparable across upgrades) |
-| `sandbox_detection` | one **wrapper name** — an inferred best guess at the tool (Docker, Podman, LXC, Firejail, Bubblewrap, gVisor, systemd-nspawn, WSL, OpenVZ, Seatbelt, Landlock, AppArmor, chroot) — plus zero or more kernel-attested **mechanisms** (`seccomp-filter`, `seccomp-notify`, `seccomp-strict`, `no-new-privs`, `landlock`, `user-namespace`) | "Is there *any* enforcement at all, and what kind?" |
+| `sandbox_detection` | one **wrapper name** — an inferred best guess at the tool (Docker, Podman, LXC, Firejail, Bubblewrap, gVisor, systemd-nspawn, WSL, OpenVZ, Seatbelt, Landlock, AppArmor, chroot) — plus zero or more kernel-attested **mechanisms** (`seccomp-filter`, `seccomp-notify`, `seccomp-strict`, `no-new-privs`, `landlock`, `user-namespace`, `restricted-token`) | "Is there *any* enforcement at all, and what kind?" |
 
 The wrapper name is a hypothesis; a mechanism is read straight off a kernel interface and is a fact. See [`CONTEXT.md`](./CONTEXT.md) for the distinction and why it matters when adding a detector.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Each row below is a `finding_type` string you will see in `report.json`, what it
 | `proxy_detection` | proxy configuration in environment variables | "Is traffic forced through a proxy the agent could subvert?" |
 | `unix_socket_detection` | Unix domain sockets visible from inside | "Can the agent talk to the Docker daemon, SSH agent, dbus, …?" |
 | `named_pipe_detection` | Windows named pipes visible from inside (Windows scans only) | "Can the agent see the host's IPC endpoints — the SSH agent, Docker's `docker_engine` pipe, …?" |
+| `named_pipe_reachable` | the named pipes this process could actually **open**, proven by a token round trip — the probe's own seeded decoy only, never a real service's pipe | "Does the sandbox stop the agent *reaching* an IPC endpoint, as opposed to merely seeing its name?" |
+| `named_pipe_creation` | a pipe the probe created and immediately destroyed | "Can the agent squat a name a privileged service will later use?" |
+| `named_pipe_probe_status` | how that measurement went: the control against a name nothing serves, whether the namespace was readable, whether the decoy was enumerated, and the per-pipe outcome | "Was this measured at all, or merely not observed?" |
 | `process_detection` / `parent_process_detection` | visible processes and the launching parent | "What else is running in the same context, and who launched the agent?" |
 | `mounted_volumes_detections` | mounted filesystems visible from inside | "What of the host filesystem is exposed?" |
 | `user_context_detection` | UID, GID, EUID, EGID | "Is the agent running as a privileged user?" |

--- a/docs/research/windows-named-pipe-enumeration.md
+++ b/docs/research/windows-named-pipe-enumeration.md
@@ -110,6 +110,47 @@ has no Windows analogue (nothing to configure — there's only one root), and
 Windows side — a Windows equivalent function would be a flat, one-shot
 enumeration, not a walk.
 
+## 4. Enumeration does not discriminate (measured 2026-08-24)
+
+Everything above answers *how to list the pipe namespace*. This section records what that
+list is worth as a sandbox measurement, because the answer turned out to be "very little",
+and that finding is the reason `named_pipe_reachable` exists.
+
+Codex CLI 0.149.1 sandboxes on Windows with a restricted token
+(`[windows] sandbox = "unelevated"` in `config.toml`). Running the probe confined by it and
+unconfined, on the same machine in the same session:
+
+| host | pipes confined | pipes unconfined |
+| --- | --- | --- |
+| Windows 11 VM, Codex CLI 0.149.1 | 57 | 57 |
+| GitHub `windows-latest` runner | 40 | 40 (unconfined `direct` baseline: 38) |
+
+Identical both times. A restricted token changes **access checks**; enumerating
+`\\.\pipe\*` is a directory read, which it does not gate. So `named_pipe_detection` cannot
+tell a sandboxed Windows agent from an unsandboxed one, and never could — the capability had
+produced no comparison data since it was built, and this is why.
+
+The same run showed the token itself *is* observable: `IsTokenRestricted` is true inside and
+false outside, which is what `sandbox_detection`'s `restricted-token` mechanism reads.
+
+### What follows from it
+
+Reachability, not visibility, is where the signal is. But it can only be measured safely
+against a name no real service can hold:
+
+- Opening a real service's pipe is **not passive**. It consumes a server instance, delivers
+  a connection event, and can hang a badly written server.
+- Reading a foreign pipe's DACL by name is *also* a client connect — the access check happens
+  on the open — so `GetNamedSecurityInfo` is not a passive alternative. Microsoft's own
+  guidance for reading a pipe's security descriptor is handle-based `GetSecurityInfo`, on a
+  handle you already hold.
+- `ImpersonateNamedPipeClient` is the attack in the pipe-squatting threat model. It must
+  never be implemented here.
+
+Hence `ReachPipeName`: a fixed private name the probe serves for itself, plus a per-pid
+control nothing ever serves, plus a token round trip so a redirected object namespace cannot
+answer in our place. See `pkg/tasks/baseline/pipereach_windows.go`.
+
 ## Sources
 
 - [Pipelist – Sysinternals | Microsoft Learn](https://learn.microsoft.com/en-us/sysinternals/downloads/pipelist)

--- a/pkg/tasks/baseline.go
+++ b/pkg/tasks/baseline.go
@@ -257,6 +257,19 @@ func appendPorts(findings *[]*reportv1.Finding, task, ft, desc string, ports []i
 	return nil
 }
 
+// appendStrings is appendPorts' twin for list-of-strings findings.
+func appendStrings(findings *[]*reportv1.Finding, task, ft, desc string, items []string) error {
+	v, err := structpb.NewValue(stringSliceToInterface(items))
+	if err != nil {
+		log.Error().Err(err).Str("finding", ft).Msg("Failed to convert strings to protobuf value")
+		return err
+	}
+	*findings = append(*findings, &reportv1.Finding{
+		FindingType: ft, Task: task, Description: desc, Value: v,
+	})
+	return nil
+}
+
 // ProxyTask produces: PROXYDETECTION
 type ProxyTask struct {
 	baseTask
@@ -372,6 +385,43 @@ func (t *SocketTask) Run(ctx context.Context, ti Inputs) ([]*reportv1.Finding, e
 			Task:        t.GetName(),
 			Description: "Named pipes detected",
 			Value:       pipesValue,
+		})
+	}
+
+	// Named-pipe REACHABILITY, measured ONLY against the probe's own seeded decoy.
+	//
+	// Enumeration above was measured not to discriminate: 57 pipes confined and 57
+	// unconfined on a Windows 11 host, 40 and 40 on a GitHub runner. Listing \\.\pipe\* is a
+	// directory read that a restricted token does not change, so the name list is identical
+	// either side of the boundary and reachability is the only place signal can come from.
+	reach := baselineTasks.MeasurePipeReach()
+
+	if names, ok := reach.Names(); ok {
+		if err := appendStrings(&findings, t.GetName(), NAMEDPIPEREACHABLE,
+			"Named pipes reached (the probe's own decoy only)", names); err != nil {
+			return nil, err
+		}
+	}
+	if names, ok := reach.CreatedPipe(); ok {
+		if err := appendStrings(&findings, t.GetName(), NAMEDPIPECREATION,
+			"Named pipe the probe could create", names); err != nil {
+			return nil, err
+		}
+	}
+	// Off Windows MeasurePipeReach returns a zero PipeReach, so this one condition keeps
+	// every reachability finding out of a non-Windows report — the same seam ListNamedPipes
+	// uses above.
+	if len(reach.Status) > 0 {
+		sv, err := structpb.NewValue(reach.Status)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to convert pipe probe status to protobuf value")
+			return nil, err
+		}
+		findings = append(findings, &reportv1.Finding{
+			FindingType: NAMEDPIPEPROBESTATUS,
+			Task:        t.GetName(),
+			Description: "How the named-pipe reachability measurement went",
+			Value:       sv,
 		})
 	}
 

--- a/pkg/tasks/baseline.go
+++ b/pkg/tasks/baseline.go
@@ -390,10 +390,10 @@ func (t *SocketTask) Run(ctx context.Context, ti Inputs) ([]*reportv1.Finding, e
 
 	// Named-pipe REACHABILITY, measured ONLY against the probe's own seeded decoy.
 	//
-	// Enumeration above was measured not to discriminate: 57 pipes confined and 57
-	// unconfined on a Windows 11 host, 40 and 40 on a GitHub runner. Listing \\.\pipe\* is a
-	// directory read that a restricted token does not change, so the name list is identical
-	// either side of the boundary and reachability is the only place signal can come from.
+	// Enumeration above was measured not to discriminate: listing \\.\pipe\* is a directory
+	// read that a restricted token does not change, so the name list is identical either side
+	// of the boundary and reachability is the only place signal can come from. The numbers and
+	// the method are in docs/research/windows-named-pipe-enumeration.md section 4.
 	reach := baselineTasks.MeasurePipeReach()
 
 	if names, ok := reach.Names(); ok {

--- a/pkg/tasks/baseline/environment.go
+++ b/pkg/tasks/baseline/environment.go
@@ -302,6 +302,23 @@ func GetContainerRuntime(tgid, pid int) ContainerRuntime {
 		return RuntimeUnknown
 	}
 
+	// A Windows restricted token says some sandbox is present and cannot say which tool built
+	// it — Codex CLI, Chromium's renderer and psexec -l all produce one. So this is the same
+	// generic "confined, unnamed" answer the no-new-privs fallback gives on Linux, and it sits
+	// in the same fallback tier for the same reason.
+	//
+	// RuntimeUnknown deliberately, rather than a new enum value. A new value needs a matching
+	// case in the switch in baseline.go, and RuntimeBubblewrap is this repository's own proof of
+	// what happens when one is missed: it is returned but has no case, so it silently produces
+	// no badge at all unless a separate ancestor walk also fires.
+	//
+	// This must be reached, not merely emitted as a mechanism: the site's sandboxOf() reports
+	// "none" for a row whose only values are mechanisms, so without a badge a correctly detected
+	// confined run would render as unsandboxed — a worse error than a vague label.
+	if isRestrictedToken() {
+		return RuntimeUnknown
+	}
+
 	return identifiedRuntime
 }
 
@@ -363,6 +380,18 @@ func ActiveMechanisms() []string {
 	// see isUserNamespaceWithUIDMap's doc comment for why the ID map shape doesn't gate this.
 	if isUserNamespaceWithUIDMap() {
 		mechanisms = append(mechanisms, "user-namespace")
+	}
+
+	// Windows restricted token (CreateRestrictedToken), read off this process's own token with
+	// IsTokenRestricted — kernel-attested in exactly the way user-namespace is attested by the
+	// uid_map, and false everywhere else.
+	//
+	// A mechanism and not a wrapper name, because the token cannot say which tool restricted it.
+	// Deliberately NOT keyed off deny-only groups or a stripped privilege set: a non-elevated
+	// administrator's UAC split token is identical on both, so that detector would report every
+	// Windows desktop as sandboxed. See isRestrictedTokenImpl for the measurement.
+	if isRestrictedToken() {
+		mechanisms = append(mechanisms, "restricted-token")
 	}
 
 	// /proc/self/status fields (all kernels that have the feature export it here)

--- a/pkg/tasks/baseline/environment_test.go
+++ b/pkg/tasks/baseline/environment_test.go
@@ -268,3 +268,62 @@ func TestGetContainerRuntimeSystemdContainerMarker(t *testing.T) {
 		})
 	}
 }
+
+// TestActiveMechanismsRestrictedToken pins "restricted-token" to the IsTokenRestricted bit and
+// to nothing else.
+//
+// The case that matters is the false one. A non-elevated administrator's UAC split token has
+// deny-only BUILTIN\Administrators and a single privilege — exactly the shape measured inside
+// Codex CLI's Windows sandbox — and must NOT be reported. Making the emitted set a pure function
+// of one bool is what guarantees that, and this table is the proof: no group, privilege or
+// integrity signal reaches the finding, because none of them is an input to any code path.
+//
+// readFile is stubbed to fail so the assertion covers the whole returned list on a Linux runner
+// too, where a container's real NoNewPrivs bit would otherwise leak in.
+func TestActiveMechanismsRestrictedToken(t *testing.T) {
+	origToken, origRead := isRestrictedToken, readFile
+	t.Cleanup(func() { isRestrictedToken, readFile = origToken, origRead })
+	readFile = func(string) ([]byte, error) { return nil, fmt.Errorf("file not found") }
+
+	for _, tt := range []struct {
+		name       string
+		restricted bool
+		want       []string
+	}{
+		{"restricted token", true, []string{"restricted-token"}},
+		{"unrestricted token", false, nil},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			isRestrictedToken = func() bool { return tt.restricted }
+			assert.Equal(t, tt.want, ActiveMechanisms())
+		})
+	}
+}
+
+// A restricted token must also reach the wrapper badge, as RuntimeUnknown.
+//
+// Without it the site's sandboxOf() reports "none" for a row whose only values are mechanisms,
+// so a correctly detected confined Windows run would render as unsandboxed. "unknown" is this
+// project's existing word for "enforcement present, tool unnameable", which is exactly the claim
+// a restricted token supports and the most it supports.
+//
+// Only the true case is asserted here. The false case is not deterministic on a Linux runner —
+// isProcSelfSetNoNewPrivs is a plain function rather than a stubbable var, and inside a container
+// it can genuinely return RuntimeUnknown for an unrelated reason. It is asserted in
+// environment_windows_test.go instead, where every other detector is a hard-false stub.
+func TestGetContainerRuntimeRestrictedTokenIsUnknown(t *testing.T) {
+	origToken, origRead, origAttr, origExists, origLandlock, origChroot :=
+		isRestrictedToken, readFile, readProcAttr, fileExistsFunc, probeForLandlock, isChroot
+	t.Cleanup(func() {
+		isRestrictedToken, readFile, readProcAttr, fileExistsFunc, probeForLandlock, isChroot =
+			origToken, origRead, origAttr, origExists, origLandlock, origChroot
+	})
+	readFile = func(string) ([]byte, error) { return nil, fmt.Errorf("file not found") }
+	readProcAttr = func(string) string { return "" }
+	fileExistsFunc = func(string) bool { return false }
+	probeForLandlock = func() (bool, error) { return false, nil }
+	isChroot = func() bool { return false }
+	isRestrictedToken = func() bool { return true }
+
+	assert.Equal(t, RuntimeUnknown, GetContainerRuntime(0, 0))
+}

--- a/pkg/tasks/baseline/environment_windows_test.go
+++ b/pkg/tasks/baseline/environment_windows_test.go
@@ -4,22 +4,35 @@
 package tasks
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/windows"
 )
 
-// The badge's false case, which is only deterministic here.
+// The badge's false case: with no restricted token and nothing else present, Windows must
+// report no runtime at all.
 //
-// On Windows every Linux detector is already a hard-false stub — isSeatbelt, probeForLandlock,
-// isChroot and isProcSelfSetNoNewPrivs all come from the !darwin/!linux files, /proc reads fail,
-// and /.dockerenv does not exist — so isRestrictedToken is the only input that can move the
-// answer. That is what makes this the real regression guard: it fails if anyone later wires a
-// second Windows signal into the runtime chain without saying so.
+// Two of the detectors ahead of it are environment-sensitive even on Windows, and both had to
+// be neutralised for this to be deterministic. The `container` env var is the awkward one:
+// os.Getenv is CASE-INSENSITIVE on Windows, because it resolves through
+// GetEnvironmentVariableW, so a variable named CONTAINER or Container in any casing reaches
+// the same check and promotes the answer to RuntimeUnknown. A GitHub windows-latest runner has
+// one; a bare Windows 11 host does not, which is why this passed locally and failed in CI.
+//
+// The remaining detectors really are hard-false stubs here — isSeatbelt, probeForLandlock,
+// isChroot and isProcSelfSetNoNewPrivs all come from the !darwin/!linux files — so with these
+// two pinned, isRestrictedToken is the only input left that can move the answer. That is what
+// makes this a regression guard: it fails if anyone later wires a second Windows signal into
+// the runtime chain without saying so.
 func TestGetContainerRuntimeRestrictedTokenOnWindows(t *testing.T) {
-	orig := isRestrictedToken
-	t.Cleanup(func() { isRestrictedToken = orig })
+	origToken, origRead, origExists := isRestrictedToken, readFile, fileExistsFunc
+	t.Cleanup(func() { isRestrictedToken, readFile, fileExistsFunc = origToken, origRead, origExists })
+	readFile = func(string) ([]byte, error) { return nil, fmt.Errorf("file not found") }
+	fileExistsFunc = func(string) bool { return false }
+	t.Setenv("container", "")
 
 	for _, tt := range []struct {
 		name       string
@@ -31,7 +44,9 @@ func TestGetContainerRuntimeRestrictedTokenOnWindows(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			isRestrictedToken = func() bool { return tt.restricted }
-			assert.Equal(t, tt.want, GetContainerRuntime(0, 0))
+			assert.Equal(t, tt.want, GetContainerRuntime(0, 0),
+				"container=%q — a non-empty value here promotes the answer to RuntimeUnknown",
+				os.Getenv("container"))
 		})
 	}
 }

--- a/pkg/tasks/baseline/environment_windows_test.go
+++ b/pkg/tasks/baseline/environment_windows_test.go
@@ -1,0 +1,75 @@
+//go:build windows
+// +build windows
+
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+// The badge's false case, which is only deterministic here.
+//
+// On Windows every Linux detector is already a hard-false stub — isSeatbelt, probeForLandlock,
+// isChroot and isProcSelfSetNoNewPrivs all come from the !darwin/!linux files, /proc reads fail,
+// and /.dockerenv does not exist — so isRestrictedToken is the only input that can move the
+// answer. That is what makes this the real regression guard: it fails if anyone later wires a
+// second Windows signal into the runtime chain without saying so.
+func TestGetContainerRuntimeRestrictedTokenOnWindows(t *testing.T) {
+	orig := isRestrictedToken
+	t.Cleanup(func() { isRestrictedToken = orig })
+
+	for _, tt := range []struct {
+		name       string
+		restricted bool
+		want       ContainerRuntime
+	}{
+		{"restricted token", true, RuntimeUnknown},
+		{"unrestricted token", false, RuntimeNotFound},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			isRestrictedToken = func() bool { return tt.restricted }
+			assert.Equal(t, tt.want, GetContainerRuntime(0, 0))
+		})
+	}
+}
+
+// The false-positive guard against the real artefact, not a mock of it.
+//
+// A UAC-filtered token is what an ordinary non-elevated administrator runs with: deny-only
+// BUILTIN\Administrators and a stripped privilege set, which is the same shape measured inside
+// Codex CLI's Windows sandbox. A detector keyed on either of those would report every Windows
+// desktop as sandboxed and turn the unconfined `direct` baseline row red.
+//
+// TokenLinkedToken hands back exactly that token on an elevated process, so the artefact is
+// available in CI with no VM and no setup. IsTokenRestricted must still say false for it.
+func TestIsRestrictedTokenNotFooledByUACFilteredToken(t *testing.T) {
+	assert.False(t, isRestrictedTokenImpl(),
+		"the test process itself is not sandboxed, so it must not report a restricted token")
+
+	var tok windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY|windows.TOKEN_DUPLICATE, &tok); err != nil {
+		t.Fatalf("OpenProcessToken: %v", err)
+	}
+	defer func() { _ = tok.Close() }()
+
+	elevated := tok.IsElevated()
+	linked, err := tok.GetLinkedToken()
+	if err != nil {
+		// A standard user has no linked token. Nothing to prove here, and skipping says so
+		// rather than passing vacuously.
+		t.Skipf("no linked token to examine (elevated=%v): %v", elevated, err)
+	}
+	defer func() { _ = linked.Close() }()
+
+	restricted, err := linked.IsRestricted()
+	if err != nil {
+		t.Fatalf("IsRestricted on the linked token: %v", err)
+	}
+	assert.False(t, restricted,
+		"a UAC-filtered token has deny-only admin groups and stripped privileges just as the "+
+			"Codex sandbox does, and must not be mistaken for a restricted token (this process "+
+			"elevated=%v)", elevated)
+}

--- a/pkg/tasks/baseline/pipereach.go
+++ b/pkg/tasks/baseline/pipereach.go
@@ -1,0 +1,42 @@
+package tasks
+
+// PipeReach is the named-pipe reachability measurement. Same split as LocalServices: what was
+// REACHED is scored, how the measurement went is not.
+//
+// Portable on purpose. The accessor rules below are the `absent != empty` contract, and they
+// are the part most worth testing on every OS — a Linux-only contributor must be able to break
+// them and see it.
+type PipeReach struct {
+	Reached []string
+	Created string // the name creation actually made, "" if it did not
+	Status  map[string]any
+}
+
+// Names returns the pipes this process reached, and whether the measurement concluded at all.
+//
+// A false second return means the caller must emit no finding. The site reads an absent finding
+// as unmeasured and an empty one as a measured negative, so publishing [] here would claim a
+// sandbox blocked something that was never planted — which is the false-blocked class of bug
+// this whole measurement layer was rebuilt to remove.
+//
+// The gate is enumeration. A decoy the scan can SEE was planted, so failing to open it is a fact
+// about policy. A decoy it cannot see is either a host nobody seeded or a namespace that hides
+// everything, and those two are not separable from in here — named_pipe_detection's own count
+// already carries that story, so nothing is claimed twice.
+func (p PipeReach) Names() ([]string, bool) {
+	if p.Status["decoy_enumerated"] != true {
+		return nil, false
+	}
+	return p.Reached, true
+}
+
+// CreatedPipe is the creation half, shaped as a list to match the enumeration finding.
+//
+// Absence is the finding contract's "blocked" — a present finding saying false would invert it —
+// so the reason a creation failed lives in Status, not here.
+func (p PipeReach) CreatedPipe() ([]string, bool) {
+	if p.Created == "" {
+		return nil, false
+	}
+	return []string{p.Created}, true
+}

--- a/pkg/tasks/baseline/pipereach.go
+++ b/pkg/tasks/baseline/pipereach.go
@@ -1,5 +1,49 @@
 package tasks
 
+import (
+	"errors"
+	"os"
+	"strconv"
+)
+
+// errNoPipeNamespace is what the seeding half of the pipe seam reports off Windows. Declared
+// here rather than in the !windows file because portable code needs to recognise it: seeding
+// the reachability decoy must tell "there is no pipe namespace on this OS" apart from "the
+// plant failed", and only the second is a skip worth counting.
+var errNoPipeNamespace = errors.New("named pipes are Windows-only")
+
+// ReachPipeName is the ONLY pipe this probe ever opens as a client, and it is deliberately
+// NOT a catalogue entry.
+//
+// Opening a real service's pipe is not passive: it consumes a server instance, delivers a
+// connection event, and can hang a badly written server. So reachability is measured only
+// against a name no real service can hold.
+//
+// Why not the catalogue names, which are what an attacker would actually target. seedPipe
+// plants a decoy at one of those only when it is free, so at SCAN time `\\.\pipe\docker_engine`
+// is either our decoy or a live Docker Desktop — and the scan is a different process from the
+// seeder, with no way to tell which. Making it tell would mean reading the seed record, which
+// puts a SAFETY property behind a filesystem read the sandbox under test may block and whose
+// TMPDIR may differ. That is exactly backwards. Whether the catalogue names are visible is
+// already answered by named_pipe_detection; what reachability adds is whether an open succeeds,
+// and that question can be asked of any pipe — so ask it of the one where the answer costs
+// nobody anything.
+//
+// A name of this shape can only ever be ours: FILE_FLAG_FIRST_PIPE_INSTANCE means the seeder
+// holds it or nobody does. It is fixed rather than per-run for the same reason the record is
+// not consulted — seeder and scan share no state, and the only channel between them is that
+// record. Two concurrent probe runs collide benignly: the second seeder's plant is skipped and
+// the scan measures the first run's decoy, which is still the probe's own.
+const ReachPipeName = pipePrefix + "sandbox-probe-reachability-decoy"
+
+// reachControlPipeName is a name nothing ever serves: the calibration control, the same
+// instrument as calibrate()'s known-free loopback port. It says what "absent" looks like on
+// THIS host, so a not-found against the decoy is interpretable rather than merely
+// disappointing. Per-pid, so two concurrent runs cannot make each other's control real.
+func reachControlPipeName() string {
+	return pipePrefix + "sandbox-probe-control-" + strconv.Itoa(os.Getpid())
+}
+
 // PipeReach is the named-pipe reachability measurement. Same split as LocalServices: what was
 // REACHED is scored, how the measurement went is not.
 //
@@ -32,11 +76,21 @@ func (p PipeReach) Names() ([]string, bool) {
 
 // CreatedPipe is the creation half, shaped as a list to match the enumeration finding.
 //
-// Absence is the finding contract's "blocked" — a present finding saying false would invert it —
-// so the reason a creation failed lives in Status, not here.
+// Absence of the FINDING means the capability was denied, so this returns a present-but-empty
+// list for a denial and reports unmeasured for anything else. The distinction matters: a
+// creation that failed because the probe built a bad name (OutcomeProbeError) says nothing
+// whatever about the sandbox, and emitting no finding for it would publish a denial the
+// sandbox never made — the false-blocked class this layer exists to remove. reach.go says the
+// same thing of that outcome: "never a statement about the sandbox".
+//
+// The reason a denial happened lives in Status, not here.
 func (p PipeReach) CreatedPipe() ([]string, bool) {
-	if p.Created == "" {
+	if p.Created != "" {
+		return []string{p.Created}, true
+	}
+	// Unmeasured: off Windows (no Status at all), or the probe itself failed.
+	if s, ok := p.Status["creation"].(string); !ok || s == string(OutcomeProbeError) {
 		return nil, false
 	}
-	return []string{p.Created}, true
+	return []string{}, true
 }

--- a/pkg/tasks/baseline/pipereach_other.go
+++ b/pkg/tasks/baseline/pipereach_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package tasks
+
+// Off Windows there is no pipe namespace, so the measurement returns a zero PipeReach: nil
+// Status, nil Reached, empty Created. Every accessor then reports "unmeasured" and no
+// named-pipe reachability finding appears in a non-Windows report at all — the same seam
+// ListNamedPipes uses to keep named_pipe_detection off other platforms.
+func MeasurePipeReach() PipeReach { return PipeReach{} }

--- a/pkg/tasks/baseline/pipereach_test.go
+++ b/pkg/tasks/baseline/pipereach_test.go
@@ -1,0 +1,111 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// THE safety test, and it deliberately carries no build tag.
+//
+// Opening a real service's pipe is not passive: it consumes a server instance, delivers a
+// connection event, and can hang a badly written server on somebody's laptop. The entire
+// safety argument for this feature is that reachability only ever opens a name no real
+// service can hold, so that invariant must be checkable by a contributor on Linux or macOS
+// who cannot run a single line of the Windows code it protects.
+//
+// The most likely way to break it is a well-meaning "why not measure docker_engine too, it
+// is more realistic". This is what stops that merging green.
+func TestReachabilityNeverTargetsACatalogueName(t *testing.T) {
+	probed := []string{ReachPipeName, reachControlPipeName()}
+
+	for _, tg := range pipeTargets() {
+		for _, p := range probed {
+			if strings.EqualFold(p, tg.Path) {
+				t.Fatalf("reachability would open %q, which is a real service's name: opening it "+
+					"consumes a server instance and delivers a connection event to somebody "+
+					"else's software", p)
+			}
+		}
+	}
+
+	for _, p := range probed {
+		assert.True(t, strings.HasPrefix(p, pipePrefix), "%q is not a pipe path", p)
+		assert.Contains(t, p, "sandbox-probe", "%q does not announce itself as the probe's own", p)
+	}
+}
+
+// The reachability decoy must never reach the catalogue, or something downstream will treat
+// it as a tool that exists in the world.
+func TestReachDecoyIsNotACatalogueEntry(t *testing.T) {
+	for _, tg := range listTargetsForHome("/home/tester", "") {
+		assert.NotEqual(t, ReachPipeName, tg.Path,
+			"the reachability decoy leaked into the target catalogue")
+	}
+}
+
+// The `absent != empty` contract, which is the rule that keeps a false "blocked" out of the
+// comparison. Portable, because the accessors are where the rule lives.
+func TestOnlyAReachedRoundTripIsScored(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		reach    PipeReach
+		want     []string
+		wantOK   bool
+		whyMatte string
+	}{
+		{
+			name:     "reached",
+			reach:    PipeReach{Reached: []string{ReachPipeName}, Status: map[string]any{"decoy_enumerated": true}},
+			want:     []string{ReachPipeName},
+			wantOK:   true,
+			whyMatte: "a completed round trip is the only proof of reach",
+		},
+		{
+			name:     "enumerated but not reachable",
+			reach:    PipeReach{Reached: []string{}, Status: map[string]any{"decoy_enumerated": true}},
+			want:     []string{},
+			wantOK:   true,
+			whyMatte: "the decoy was planted and could not be opened: a measured negative, which is a real finding",
+		},
+		{
+			name:     "decoy never enumerated",
+			reach:    PipeReach{Reached: []string{}, Status: map[string]any{"decoy_enumerated": false}},
+			want:     nil,
+			wantOK:   false,
+			whyMatte: "nothing was planted, so publishing [] would claim a sandbox blocked something never tested",
+		},
+		{
+			name:     "namespace denied",
+			reach:    PipeReach{Reached: []string{}, Status: map[string]any{"namespace": "denied"}},
+			want:     nil,
+			wantOK:   false,
+			whyMatte: "the enumeration itself failed, so nothing about opening is knowable",
+		},
+		{
+			name:     "off windows",
+			reach:    PipeReach{},
+			want:     nil,
+			wantOK:   false,
+			whyMatte: "a zero PipeReach must produce no finding at all",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := tt.reach.Names()
+			assert.Equal(t, tt.wantOK, ok, tt.whyMatte)
+			assert.Equal(t, tt.want, got, tt.whyMatte)
+		})
+	}
+}
+
+// Creation is reported by presence, never by a finding that says false — that would invert
+// the whole report contract, in which an absent finding means the capability was denied.
+func TestCreatedPipeReportsByPresence(t *testing.T) {
+	got, ok := PipeReach{Created: `\\.\pipe\x`}.CreatedPipe()
+	assert.True(t, ok)
+	assert.Equal(t, []string{`\\.\pipe\x`}, got)
+
+	_, ok = PipeReach{Created: ""}.CreatedPipe()
+	assert.False(t, ok, "a failed creation must emit no finding, not a finding saying false")
+}

--- a/pkg/tasks/baseline/pipereach_test.go
+++ b/pkg/tasks/baseline/pipereach_test.go
@@ -49,52 +49,52 @@ func TestReachDecoyIsNotACatalogueEntry(t *testing.T) {
 // comparison. Portable, because the accessors are where the rule lives.
 func TestOnlyAReachedRoundTripIsScored(t *testing.T) {
 	for _, tt := range []struct {
-		name     string
-		reach    PipeReach
-		want     []string
-		wantOK   bool
-		whyMatte string
+		name         string
+		reach        PipeReach
+		want         []string
+		wantOK       bool
+		whyItMatters string
 	}{
 		{
-			name:     "reached",
-			reach:    PipeReach{Reached: []string{ReachPipeName}, Status: map[string]any{"decoy_enumerated": true}},
-			want:     []string{ReachPipeName},
-			wantOK:   true,
-			whyMatte: "a completed round trip is the only proof of reach",
+			name:         "reached",
+			reach:        PipeReach{Reached: []string{ReachPipeName}, Status: map[string]any{"decoy_enumerated": true}},
+			want:         []string{ReachPipeName},
+			wantOK:       true,
+			whyItMatters: "a completed round trip is the only proof of reach",
 		},
 		{
-			name:     "enumerated but not reachable",
-			reach:    PipeReach{Reached: []string{}, Status: map[string]any{"decoy_enumerated": true}},
-			want:     []string{},
-			wantOK:   true,
-			whyMatte: "the decoy was planted and could not be opened: a measured negative, which is a real finding",
+			name:         "enumerated but not reachable",
+			reach:        PipeReach{Reached: []string{}, Status: map[string]any{"decoy_enumerated": true}},
+			want:         []string{},
+			wantOK:       true,
+			whyItMatters: "the decoy was planted and could not be opened: a measured negative, which is a real finding",
 		},
 		{
-			name:     "decoy never enumerated",
-			reach:    PipeReach{Reached: []string{}, Status: map[string]any{"decoy_enumerated": false}},
-			want:     nil,
-			wantOK:   false,
-			whyMatte: "nothing was planted, so publishing [] would claim a sandbox blocked something never tested",
+			name:         "decoy never enumerated",
+			reach:        PipeReach{Reached: []string{}, Status: map[string]any{"decoy_enumerated": false}},
+			want:         nil,
+			wantOK:       false,
+			whyItMatters: "nothing was planted, so publishing [] would claim a sandbox blocked something never tested",
 		},
 		{
-			name:     "namespace denied",
-			reach:    PipeReach{Reached: []string{}, Status: map[string]any{"namespace": "denied"}},
-			want:     nil,
-			wantOK:   false,
-			whyMatte: "the enumeration itself failed, so nothing about opening is knowable",
+			name:         "namespace denied",
+			reach:        PipeReach{Reached: []string{}, Status: map[string]any{"namespace": "denied"}},
+			want:         nil,
+			wantOK:       false,
+			whyItMatters: "the enumeration itself failed, so nothing about opening is knowable",
 		},
 		{
-			name:     "off windows",
-			reach:    PipeReach{},
-			want:     nil,
-			wantOK:   false,
-			whyMatte: "a zero PipeReach must produce no finding at all",
+			name:         "off windows",
+			reach:        PipeReach{},
+			want:         nil,
+			wantOK:       false,
+			whyItMatters: "a zero PipeReach must produce no finding at all",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := tt.reach.Names()
-			assert.Equal(t, tt.wantOK, ok, tt.whyMatte)
-			assert.Equal(t, tt.want, got, tt.whyMatte)
+			assert.Equal(t, tt.wantOK, ok, tt.whyItMatters)
+			assert.Equal(t, tt.want, got, tt.whyItMatters)
 		})
 	}
 }

--- a/pkg/tasks/baseline/pipereach_windows.go
+++ b/pkg/tasks/baseline/pipereach_windows.go
@@ -1,0 +1,272 @@
+//go:build windows
+// +build windows
+
+package tasks
+
+import (
+	"errors"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// classifyWin32 is classify()'s sibling for the Win32 error space.
+//
+// It is a separate function rather than an extension of the helpers in errno_windows.go,
+// and the reason is a trap that compiles cleanly. Those helpers match Winsock numbers
+// (10000+); a CreateFile failure carries a low Win32 code. The two spaces do not collide, so
+// every predicate there returns false for every pipe error and classify() falls through to
+// OutcomeProbeError — including ERROR_ACCESS_DENIED, the single most interesting result,
+// reported as a malfunction of the probe rather than as the sandbox doing its job.
+func classifyWin32(err error) (Outcome, string, string) {
+	if err == nil {
+		return OutcomeReachable, "", ""
+	}
+
+	var se *os.SyscallError
+	call := ""
+	if errors.As(err, &se) {
+		call = se.Syscall
+	}
+
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return win32Outcome(errno), call, win32Name(errno)
+	}
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return OutcomeSilent, call, "deadline"
+	}
+	return OutcomeProbeError, call, ""
+}
+
+// win32Outcome maps a Win32 error from a pipe open onto the shared Outcome vocabulary.
+//
+// Every one of these codes is forgeable: a filesystem minifilter or an object-manager filter
+// chooses what it returns, exactly as iptables can synthesise a TCP reset. So the rule from
+// reach.go transfers unweakened — only OutcomeReachable is scored, and it is reached only by
+// a completed token round trip. Everything below is diagnostic.
+func win32Outcome(e syscall.Errno) Outcome {
+	switch e {
+	// The name did not resolve, so no access check was ever reached. That is "no route",
+	// not "denied" — and it is also what a private object namespace (a server silo, an
+	// AppContainer) looks like from the inside.
+	case windows.ERROR_FILE_NOT_FOUND,
+		windows.ERROR_PATH_NOT_FOUND,
+		windows.ERROR_BAD_NETPATH:
+		return OutcomeUnreachable
+
+	// The name resolved and the access check FAILED. A restricted token or a DACL denial
+	// lands exactly here. This is the case the Winsock helpers lose.
+	case windows.ERROR_ACCESS_DENIED:
+		return OutcomeBlocked
+
+	// The wait expired with nothing back. Ambiguous by construction.
+	case windows.ERROR_SEM_TIMEOUT:
+		return OutcomeSilent
+
+	// NPFS answered: every instance is in use. A real refusal from a real server, and
+	// forgeable like the rest. Against our own decoy — unlimited instances, served
+	// serially — it should never appear, so seeing it is itself a signal.
+	case windows.ERROR_PIPE_BUSY:
+		return OutcomeRefused
+
+	// None of these can come from a CreateFile against a live server. They mean our own
+	// server went away mid-round-trip, or we built a bad name: facts about the probe, never
+	// about the sandbox. That distinction is the one the old port scanner lost.
+	case windows.ERROR_PIPE_NOT_CONNECTED,
+		windows.ERROR_BROKEN_PIPE,
+		windows.ERROR_NO_DATA,
+		windows.ERROR_INVALID_NAME,
+		windows.ERROR_NOT_SUPPORTED,
+		windows.ERROR_OPERATION_ABORTED:
+		return OutcomeProbeError
+	}
+	// Same rule as classify(): an error we have no opinion on is not silence and is not a
+	// verdict. Say so rather than guessing.
+	return OutcomeProbeError
+}
+
+// win32Name is the stable symbol for a Win32 error, mirroring errnoName. The fallback is the
+// OS message, which is localised and therefore unfit to compare across runs — so anything
+// worth reasoning about belongs in the switch.
+func win32Name(e syscall.Errno) string {
+	switch e {
+	case windows.ERROR_FILE_NOT_FOUND:
+		return "ERROR_FILE_NOT_FOUND"
+	case windows.ERROR_PATH_NOT_FOUND:
+		return "ERROR_PATH_NOT_FOUND"
+	case windows.ERROR_ACCESS_DENIED:
+		return "ERROR_ACCESS_DENIED"
+	case windows.ERROR_NOT_SUPPORTED:
+		return "ERROR_NOT_SUPPORTED"
+	case windows.ERROR_BAD_NETPATH:
+		return "ERROR_BAD_NETPATH"
+	case windows.ERROR_BROKEN_PIPE:
+		return "ERROR_BROKEN_PIPE"
+	case windows.ERROR_SEM_TIMEOUT:
+		return "ERROR_SEM_TIMEOUT"
+	case windows.ERROR_INVALID_NAME:
+		return "ERROR_INVALID_NAME"
+	case windows.ERROR_PIPE_BUSY:
+		return "ERROR_PIPE_BUSY"
+	case windows.ERROR_NO_DATA:
+		return "ERROR_NO_DATA"
+	case windows.ERROR_PIPE_NOT_CONNECTED:
+		return "ERROR_PIPE_NOT_CONNECTED"
+	case windows.ERROR_OPERATION_ABORTED:
+		return "ERROR_OPERATION_ABORTED"
+	}
+	return e.Error()
+}
+
+// readPipeToken opens name as a CLIENT and reads back what the server writes.
+//
+// This is a client connect. It consumes a server instance and delivers a connection event,
+// so it is only ever pointed at a name this probe serves itself — ReachPipeName or the
+// per-pid control. Never at a catalogue name; see ReachPipeName for why that distinction
+// cannot be made safely at scan time.
+func readPipeToken(name string) (string, error) {
+	if name == "" {
+		return "", os.ErrInvalid
+	}
+	p, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return "", err
+	}
+	h, err := windows.CreateFile(p, windows.GENERIC_READ, 0, nil,
+		windows.OPEN_EXISTING, 0, 0)
+	if err != nil {
+		// Wrapped so classifyWin32 recovers the syscall name through the same errors.As
+		// walk classify() uses on net's errors.
+		return "", &os.SyscallError{Syscall: "CreateFile", Err: err}
+	}
+	defer windows.CloseHandle(h)
+
+	buf := make([]byte, len(name))
+	done := make(chan error, 1)
+	go func() {
+		for got := 0; got < len(buf); {
+			var n uint32
+			if rErr := windows.ReadFile(h, buf[got:], &n, nil); rErr != nil {
+				done <- &os.SyscallError{Syscall: "ReadFile", Err: rErr}
+				return
+			}
+			if n == 0 {
+				done <- &os.SyscallError{Syscall: "ReadFile", Err: windows.ERROR_BROKEN_PIPE}
+				return
+			}
+			got += int(n)
+		}
+		done <- nil
+	}()
+
+	select {
+	case rErr := <-done:
+		if rErr != nil {
+			return "", rErr
+		}
+		return string(buf), nil
+	case <-time.After(probeDeadline):
+		// Cancel rather than leak a read against a handle the defer is about to close, then
+		// wait for the reader to actually be gone.
+		_ = windows.CancelIoEx(h, nil)
+		<-done
+		return "", os.ErrDeadlineExceeded
+	}
+}
+
+// probeOwnPipe attempts one round trip against a name this probe owns.
+func probeOwnPipe(name string) (Outcome, string, string) {
+	got, err := readPipeToken(name)
+	if err != nil {
+		return classifyWin32(err)
+	}
+	if !strings.EqualFold(got, name) {
+		// Something opened, something answered, and it was not us. That is not reach: the
+		// measurement did not conclude, and saying so beats scoring a stranger's pipe.
+		return OutcomeProbeError, "ReadFile", "token_mismatch"
+	}
+	return OutcomeReachable, "", ""
+}
+
+// createCheck creates — and immediately destroys — one pipe under a name only this process
+// can hold. Safe by construction: the name carries this pid, FILE_FLAG_FIRST_PIPE_INSTANCE
+// means creation fails rather than joining anything, and the handle is closed before this
+// returns.
+func createCheck() (string, error) {
+	name := pipePrefix + "sandbox-probe-create-check-" + strconv.Itoa(os.Getpid())
+	h, err := createPipeInstance(name, true)
+	if err != nil {
+		return "", err
+	}
+	_ = windows.CloseHandle(h)
+	return name, nil
+}
+
+// MeasurePipeReach is the Windows named-pipe reachability measurement.
+//
+// SAFETY, and the reason this function is short: it opens exactly two names, both of which
+// only this probe can own. Opening a REAL service's pipe is not passive — it consumes a
+// server instance, delivers a connection event, and can hang or break a badly written
+// server. Reading a foreign pipe's DACL by name is a client connect too, per Microsoft's own
+// documentation, so there is no passive alternative. The catalogue names are NEVER probed.
+//
+// NEVER add ImpersonateNamedPipeClient. That is the attack, not the measurement.
+func MeasurePipeReach() PipeReach {
+	out := PipeReach{Status: map[string]any{"method": "own-decoy-roundtrip-v1"}}
+
+	// Calibrate BEFORE probing the decoy, the same order and for the same reason as
+	// calibrate() in localsvc.go: a name nothing ever serves says what "absent" looks like
+	// on THIS host, so a not-found against the decoy is interpretable.
+	c, _, cErrno := probeOwnPipe(reachControlPipeName())
+	out.Status["control"] = string(c)
+	if cErrno != "" {
+		out.Status["control_errno"] = cErrno
+	}
+
+	// Enumeration is a DIFFERENT access check from opening. Recording whether the decoy is
+	// even visible is what separates "the sandbox hid it" from "nobody seeded it", and it
+	// is the gate on whether anything is claimed at all.
+	pipes, err := ListNamedPipes()
+	if err != nil {
+		out.Status["namespace"] = "denied"
+		out.Status["error"] = err.Error()
+	} else {
+		out.Status["namespace"] = "read"
+		out.Status["pipes_found"] = float64(len(pipes))
+		out.Status["decoy_enumerated"] = slices.ContainsFunc(pipes,
+			func(p string) bool { return strings.EqualFold(p, ReachPipeName) })
+	}
+
+	o, call, errno := probeOwnPipe(ReachPipeName)
+	row := map[string]any{"pipe": ReachPipeName, "outcome": string(o)}
+	if call != "" {
+		row["syscall"] = call
+	}
+	if errno != "" {
+		row["errno"] = errno
+	}
+	out.Status["results"] = []any{row} // structpb takes the basic Go kinds only
+
+	out.Reached = []string{}
+	if o == OutcomeReachable {
+		out.Reached = append(out.Reached, ReachPipeName)
+	}
+
+	// Creation is the third access check. A filter can allow enumeration and deny
+	// CreateNamedPipe, so it is measured rather than inferred from the other two.
+	if name, cErr := createCheck(); cErr == nil {
+		out.Created = name
+		out.Status["creation"] = "ok"
+	} else {
+		co, _, cn := classifyWin32(cErr)
+		out.Status["creation"] = string(co)
+		out.Status["creation_errno"] = cn
+	}
+	return out
+}

--- a/pkg/tasks/baseline/pipereach_windows.go
+++ b/pkg/tasks/baseline/pipereach_windows.go
@@ -44,82 +44,62 @@ func classifyWin32(err error) (Outcome, string, string) {
 	return OutcomeProbeError, call, ""
 }
 
-// win32Outcome maps a Win32 error from a pipe open onto the shared Outcome vocabulary.
+// win32Errors is the single table behind both the outcome and the stable name of a Win32
+// error from a pipe open. One table rather than two switches over the same constants: they
+// have to agree, and two switches that must agree are two switches that will eventually not.
 //
-// Every one of these codes is forgeable: a filesystem minifilter or an object-manager filter
+// Every one of these codes is FORGEABLE. A filesystem minifilter or an object-manager filter
 // chooses what it returns, exactly as iptables can synthesise a TCP reset. So the rule from
-// reach.go transfers unweakened — only OutcomeReachable is scored, and it is reached only by
-// a completed token round trip. Everything below is diagnostic.
-func win32Outcome(e syscall.Errno) Outcome {
-	switch e {
-	// The name did not resolve, so no access check was ever reached. That is "no route",
-	// not "denied" — and it is also what a private object namespace (a server silo, an
+// reach.go transfers unweakened: only OutcomeReachable is scored, and it is reached only by a
+// completed token round trip. Everything here is diagnostic.
+var win32Errors = map[syscall.Errno]struct {
+	outcome Outcome
+	name    string
+}{
+	// The name did not resolve, so no access check was ever reached. That is "no route", not
+	// "denied" — and it is also what a private object namespace (a server silo, an
 	// AppContainer) looks like from the inside.
-	case windows.ERROR_FILE_NOT_FOUND,
-		windows.ERROR_PATH_NOT_FOUND,
-		windows.ERROR_BAD_NETPATH:
-		return OutcomeUnreachable
+	windows.ERROR_FILE_NOT_FOUND: {OutcomeUnreachable, "ERROR_FILE_NOT_FOUND"},
+	windows.ERROR_PATH_NOT_FOUND: {OutcomeUnreachable, "ERROR_PATH_NOT_FOUND"},
+	windows.ERROR_BAD_NETPATH:    {OutcomeUnreachable, "ERROR_BAD_NETPATH"},
 
-	// The name resolved and the access check FAILED. A restricted token or a DACL denial
-	// lands exactly here. This is the case the Winsock helpers lose.
-	case windows.ERROR_ACCESS_DENIED:
-		return OutcomeBlocked
+	// The name resolved and the access check FAILED. A restricted token or a DACL denial lands
+	// exactly here. This is the case the Winsock helpers lose.
+	windows.ERROR_ACCESS_DENIED: {OutcomeBlocked, "ERROR_ACCESS_DENIED"},
 
 	// The wait expired with nothing back. Ambiguous by construction.
-	case windows.ERROR_SEM_TIMEOUT:
-		return OutcomeSilent
+	windows.ERROR_SEM_TIMEOUT: {OutcomeSilent, "ERROR_SEM_TIMEOUT"},
 
-	// NPFS answered: every instance is in use. A real refusal from a real server, and
-	// forgeable like the rest. Against our own decoy — unlimited instances, served
-	// serially — it should never appear, so seeing it is itself a signal.
-	case windows.ERROR_PIPE_BUSY:
-		return OutcomeRefused
+	// NPFS answered: every instance is in use. A real refusal from a real server, and forgeable
+	// like the rest. Against our own decoy — unlimited instances, served serially — it should
+	// never appear, so seeing it is itself a signal.
+	windows.ERROR_PIPE_BUSY: {OutcomeRefused, "ERROR_PIPE_BUSY"},
 
-	// None of these can come from a CreateFile against a live server. They mean our own
-	// server went away mid-round-trip, or we built a bad name: facts about the probe, never
-	// about the sandbox. That distinction is the one the old port scanner lost.
-	case windows.ERROR_PIPE_NOT_CONNECTED,
-		windows.ERROR_BROKEN_PIPE,
-		windows.ERROR_NO_DATA,
-		windows.ERROR_INVALID_NAME,
-		windows.ERROR_NOT_SUPPORTED,
-		windows.ERROR_OPERATION_ABORTED:
-		return OutcomeProbeError
+	// None of these can come from a CreateFile against a live server. They mean our own server
+	// went away mid-round-trip, or we built a bad name: facts about the probe, never about the
+	// sandbox. That distinction is the one the old port scanner lost.
+	windows.ERROR_PIPE_NOT_CONNECTED: {OutcomeProbeError, "ERROR_PIPE_NOT_CONNECTED"},
+	windows.ERROR_BROKEN_PIPE:        {OutcomeProbeError, "ERROR_BROKEN_PIPE"},
+	windows.ERROR_NO_DATA:            {OutcomeProbeError, "ERROR_NO_DATA"},
+	windows.ERROR_INVALID_NAME:       {OutcomeProbeError, "ERROR_INVALID_NAME"},
+	windows.ERROR_NOT_SUPPORTED:      {OutcomeProbeError, "ERROR_NOT_SUPPORTED"},
+	windows.ERROR_OPERATION_ABORTED:  {OutcomeProbeError, "ERROR_OPERATION_ABORTED"},
+}
+
+// win32Outcome and win32Name read that table. An error the table has no opinion on is not
+// silence and is not a verdict, so it says so rather than guessing; its name falls back to the
+// OS message, which is localised and unfit to compare across runs — anything worth reasoning
+// about belongs in the table.
+func win32Outcome(e syscall.Errno) Outcome {
+	if v, ok := win32Errors[e]; ok {
+		return v.outcome
 	}
-	// Same rule as classify(): an error we have no opinion on is not silence and is not a
-	// verdict. Say so rather than guessing.
 	return OutcomeProbeError
 }
 
-// win32Name is the stable symbol for a Win32 error, mirroring errnoName. The fallback is the
-// OS message, which is localised and therefore unfit to compare across runs — so anything
-// worth reasoning about belongs in the switch.
 func win32Name(e syscall.Errno) string {
-	switch e {
-	case windows.ERROR_FILE_NOT_FOUND:
-		return "ERROR_FILE_NOT_FOUND"
-	case windows.ERROR_PATH_NOT_FOUND:
-		return "ERROR_PATH_NOT_FOUND"
-	case windows.ERROR_ACCESS_DENIED:
-		return "ERROR_ACCESS_DENIED"
-	case windows.ERROR_NOT_SUPPORTED:
-		return "ERROR_NOT_SUPPORTED"
-	case windows.ERROR_BAD_NETPATH:
-		return "ERROR_BAD_NETPATH"
-	case windows.ERROR_BROKEN_PIPE:
-		return "ERROR_BROKEN_PIPE"
-	case windows.ERROR_SEM_TIMEOUT:
-		return "ERROR_SEM_TIMEOUT"
-	case windows.ERROR_INVALID_NAME:
-		return "ERROR_INVALID_NAME"
-	case windows.ERROR_PIPE_BUSY:
-		return "ERROR_PIPE_BUSY"
-	case windows.ERROR_NO_DATA:
-		return "ERROR_NO_DATA"
-	case windows.ERROR_PIPE_NOT_CONNECTED:
-		return "ERROR_PIPE_NOT_CONNECTED"
-	case windows.ERROR_OPERATION_ABORTED:
-		return "ERROR_OPERATION_ABORTED"
+	if v, ok := win32Errors[e]; ok {
+		return v.name
 	}
 	return e.Error()
 }

--- a/pkg/tasks/baseline/pipereach_windows_test.go
+++ b/pkg/tasks/baseline/pipereach_windows_test.go
@@ -72,7 +72,6 @@ func TestClassifyWin32SeparatesDeniedFromProbeError(t *testing.T) {
 // The rework's whole point: the decoy must answer more than one client. Today's
 // create-and-sleep server serves at most one and never recycles the instance.
 func TestServePipeAnswersRepeatedClients(t *testing.T) {
-	windowsOnly(t)
 	name := testPipeName(t)
 	served := make(chan error, 1)
 	go func() { served <- ServePipe(name, 30*time.Second) }()
@@ -100,7 +99,6 @@ func TestServePipeAnswersRepeatedClients(t *testing.T) {
 // standing between a blocking ConnectNamedPipe and a decoy that outlives every scan — a pipe
 // server left running on a developer's laptop until reboot.
 func TestServePipeExpiresWhileWaitingForAClient(t *testing.T) {
-	windowsOnly(t)
 	name := testPipeName(t)
 	done := make(chan error, 1)
 	go func() { done <- ServePipe(name, 2*time.Second) }()
@@ -118,7 +116,6 @@ func TestServePipeExpiresWhileWaitingForAClient(t *testing.T) {
 // and an access check passed; it does not prove WHICH object answered, and Windows redirects
 // object namespaces for exactly the container-shaped isolation being measured.
 func TestReachRejectsAForeignToken(t *testing.T) {
-	windowsOnly(t)
 	name := testPipeName(t) + "-foreign"
 
 	h, err := createPipeInstance(name, true)
@@ -142,7 +139,6 @@ func TestReachRejectsAForeignToken(t *testing.T) {
 
 // End to end, and the last assertion is the one guarding the false-blocked class of bug.
 func TestSeedPlantsAndScanReachesTheReachabilityDecoy(t *testing.T) {
-	windowsOnly(t)
 	record := filepath.Join(t.TempDir(), "record.json")
 	shortLifetime(t, 60*time.Second)
 	t.Cleanup(func() { _, _ = CleanupSeeded(record) })
@@ -173,10 +169,12 @@ func TestSeedPlantsAndScanReachesTheReachabilityDecoy(t *testing.T) {
 
 // Creation is the third access check, measured rather than inferred.
 func TestCreationIsMeasuredAndPidScoped(t *testing.T) {
-	windowsOnly(t)
 	r := MeasurePipeReach()
 	names, ok := r.CreatedPipe()
-	require.True(t, ok, "creation failed on an unconfined runner: %v", r.Status["creation_errno"])
+	require.True(t, ok, "the measurement did not conclude: %v", r.Status["creation_errno"])
+	// An empty list is a legitimate answer — a sandbox denying CreateNamedPipe — so it must not
+	// index-panic here. On an unconfined runner creation succeeds and the name carries the pid.
+	require.Lenf(t, names, 1, "creation was denied on an unconfined runner: %v", r.Status["creation_errno"])
 	assert.Contains(t, names[0], strconv.Itoa(os.Getpid()), "the name must be scoped to this process")
 	assert.False(t, pipeExists(names[0]), "the check pipe must be closed before the call returns")
 }

--- a/pkg/tasks/baseline/pipereach_windows_test.go
+++ b/pkg/tasks/baseline/pipereach_windows_test.go
@@ -148,9 +148,15 @@ func TestSeedPlantsAndScanReachesTheReachabilityDecoy(t *testing.T) {
 	t.Cleanup(func() { _, _ = CleanupSeeded(record) })
 
 	// Deliberately no catalogue targets: the reachability decoy must be planted on its own.
+	//
+	// It is not counted in SeedResult — Planted and Skipped tally the caller's targets, and
+	// this is an instrument the probe plants for itself. So an empty target list must report
+	// nothing planted while still leaving a reachable decoy behind, and both halves of that
+	// are asserted here.
 	res, err := SeedTargets(nil, record)
 	require.NoError(t, err)
-	require.Equal(t, 1, res.Planted, "the reachability decoy was not planted")
+	assert.Equal(t, 0, res.Planted, "the probe's own instrument must not inflate the caller's tally")
+	assert.Equal(t, 0, res.Skipped, "nor its skip count")
 
 	names, ok := MeasurePipeReach().Names()
 	assert.True(t, ok, "the decoy was planted, so the measurement must conclude")

--- a/pkg/tasks/baseline/pipereach_windows_test.go
+++ b/pkg/tasks/baseline/pipereach_windows_test.go
@@ -1,0 +1,176 @@
+//go:build windows
+// +build windows
+
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// The Win32 error space, mapped. Every code here is forgeable by a filesystem minifilter or
+// an object-manager filter, which is why only OutcomeReachable is ever scored — but the
+// distinctions still have to be right, because they are what a reader uses to tell a policy
+// denial from a probe malfunction.
+func TestClassifyWin32Mapping(t *testing.T) {
+	for _, tt := range []struct {
+		errno syscall.Errno
+		want  Outcome
+		name  string
+	}{
+		{windows.ERROR_FILE_NOT_FOUND, OutcomeUnreachable, "ERROR_FILE_NOT_FOUND"},
+		{windows.ERROR_PATH_NOT_FOUND, OutcomeUnreachable, "ERROR_PATH_NOT_FOUND"},
+		{windows.ERROR_BAD_NETPATH, OutcomeUnreachable, "ERROR_BAD_NETPATH"},
+		{windows.ERROR_ACCESS_DENIED, OutcomeBlocked, "ERROR_ACCESS_DENIED"},
+		{windows.ERROR_SEM_TIMEOUT, OutcomeSilent, "ERROR_SEM_TIMEOUT"},
+		{windows.ERROR_PIPE_BUSY, OutcomeRefused, "ERROR_PIPE_BUSY"},
+		{windows.ERROR_PIPE_NOT_CONNECTED, OutcomeProbeError, "ERROR_PIPE_NOT_CONNECTED"},
+		{windows.ERROR_BROKEN_PIPE, OutcomeProbeError, "ERROR_BROKEN_PIPE"},
+		{windows.ERROR_NO_DATA, OutcomeProbeError, "ERROR_NO_DATA"},
+		{windows.ERROR_OPERATION_ABORTED, OutcomeProbeError, "ERROR_OPERATION_ABORTED"},
+		// An error we have no opinion on is not silence and is not a verdict.
+		{windows.ERROR_INVALID_HANDLE, OutcomeProbeError, ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, call, name := classifyWin32(&os.SyscallError{Syscall: "CreateFile", Err: tt.errno})
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, "CreateFile", call, "the syscall name must survive the unwrap")
+			if tt.name != "" {
+				assert.Equal(t, tt.name, name, "the stable symbol, not a localised OS message")
+			}
+		})
+	}
+}
+
+// The regression this whole file exists for.
+//
+// classify() matches Winsock numbers (10000+); a pipe open returns low Win32 codes. They do
+// not collide, so classify() silently reports ERROR_ACCESS_DENIED — a sandbox denying access,
+// the single most interesting result — as a malfunction of the probe. Asserting both sides is
+// what stops someone "simplifying" the two functions into one.
+func TestClassifyWin32SeparatesDeniedFromProbeError(t *testing.T) {
+	denied := &os.SyscallError{Syscall: "CreateFile", Err: windows.ERROR_ACCESS_DENIED}
+
+	got, _, _ := classify(denied)
+	assert.Equal(t, OutcomeProbeError, got,
+		"classify is Winsock-only and cannot read a Win32 code; if this ever changes, "+
+			"revisit whether the two classifiers should still be separate")
+
+	got, _, _ = classifyWin32(denied)
+	assert.Equal(t, OutcomeBlocked, got,
+		"a denied pipe open is the sandbox doing its job, not the probe failing")
+}
+
+// The rework's whole point: the decoy must answer more than one client. Today's
+// create-and-sleep server serves at most one and never recycles the instance.
+func TestServePipeAnswersRepeatedClients(t *testing.T) {
+	windowsOnly(t)
+	name := testPipeName(t)
+	served := make(chan error, 1)
+	go func() { served <- ServePipe(name, 30*time.Second) }()
+	require.True(t, waitForPipe(t, name, true), "the decoy server never came up")
+
+	for i := range 3 {
+		got, _, errno := probeOwnPipe(name)
+		assert.Equalf(t, OutcomeReachable, got, "round trip %d failed with %s", i+1, errno)
+		assert.Truef(t, pipeExists(name),
+			"the name lapsed out of the namespace after round trip %d; a scan enumerating at "+
+				"that instant would miss a decoy that is really there", i+1)
+	}
+
+	select {
+	case err := <-served:
+		t.Fatalf("the server exited early: %v", err)
+	default:
+	}
+}
+
+// The belt, and the direct answer to "does the lifetime still fire when the server is blocked
+// waiting for a client that never comes?".
+//
+// Before the rework this passed trivially against time.Sleep(d). It is now the only thing
+// standing between a blocking ConnectNamedPipe and a decoy that outlives every scan — a pipe
+// server left running on a developer's laptop until reboot.
+func TestServePipeExpiresWhileWaitingForAClient(t *testing.T) {
+	windowsOnly(t)
+	name := testPipeName(t)
+	done := make(chan error, 1)
+	go func() { done <- ServePipe(name, 2*time.Second) }()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("ServePipe never returned with no client connecting: the self-expiry cannot " +
+			"interrupt ConnectNamedPipe, so a decoy would outlive its lifetime")
+	}
+}
+
+// The token check is load-bearing, not decorative. A successful open proves a name resolved
+// and an access check passed; it does not prove WHICH object answered, and Windows redirects
+// object namespaces for exactly the container-shaped isolation being measured.
+func TestReachRejectsAForeignToken(t *testing.T) {
+	windowsOnly(t)
+	name := testPipeName(t) + "-foreign"
+
+	h, err := createPipeInstance(name, true)
+	require.NoError(t, err)
+	go func() {
+		defer windows.CloseHandle(h)
+		if cErr := windows.ConnectNamedPipe(h, nil); cErr != nil &&
+			cErr != windows.ERROR_PIPE_CONNECTED {
+			return
+		}
+		var n uint32
+		_ = windows.WriteFile(h, []byte("not-the-name-you-asked-for"), &n, nil)
+		_ = windows.FlushFileBuffers(h)
+	}()
+	require.True(t, waitForPipe(t, name, true))
+
+	got, _, _ := probeOwnPipe(name)
+	assert.NotEqual(t, OutcomeReachable, got,
+		"something answered that was not our server, so the measurement did not conclude")
+}
+
+// End to end, and the last assertion is the one guarding the false-blocked class of bug.
+func TestSeedPlantsAndScanReachesTheReachabilityDecoy(t *testing.T) {
+	windowsOnly(t)
+	record := filepath.Join(t.TempDir(), "record.json")
+	shortLifetime(t, 60*time.Second)
+	t.Cleanup(func() { _, _ = CleanupSeeded(record) })
+
+	// Deliberately no catalogue targets: the reachability decoy must be planted on its own.
+	res, err := SeedTargets(nil, record)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Planted, "the reachability decoy was not planted")
+
+	names, ok := MeasurePipeReach().Names()
+	assert.True(t, ok, "the decoy was planted, so the measurement must conclude")
+	assert.Equal(t, []string{ReachPipeName}, names)
+
+	_, err = CleanupSeeded(record)
+	require.NoError(t, err)
+
+	_, ok = MeasurePipeReach().Names()
+	assert.False(t, ok,
+		"with no decoy planted the answer must be unmeasured, not an empty list: publishing [] "+
+			"would claim a sandbox blocked something that was never there")
+}
+
+// Creation is the third access check, measured rather than inferred.
+func TestCreationIsMeasuredAndPidScoped(t *testing.T) {
+	windowsOnly(t)
+	r := MeasurePipeReach()
+	names, ok := r.CreatedPipe()
+	require.True(t, ok, "creation failed on an unconfined runner: %v", r.Status["creation_errno"])
+	assert.Contains(t, names[0], strconv.Itoa(os.Getpid()), "the name must be scoped to this process")
+	assert.False(t, pipeExists(names[0]), "the check pipe must be closed before the call returns")
+}

--- a/pkg/tasks/baseline/pipes_other.go
+++ b/pkg/tasks/baseline/pipes_other.go
@@ -4,7 +4,6 @@
 package tasks
 
 import (
-	"errors"
 	"time"
 )
 
@@ -13,12 +12,6 @@ import (
 // a non-Windows report entirely: the caller emits the finding only for a
 // non-nil list.
 func ListNamedPipes() ([]string, error) { return nil, nil }
-
-// errNoPipeNamespace is what the seeding half of the pipe seam reports off
-// Windows. Unreachable in production — pipe targets are windows-scoped and
-// ListTargets filters to the running OS — so if it ever fires it is one skipped
-// entry, not a failed run.
-var errNoPipeNamespace = errors.New("named pipes are Windows-only")
 
 func ServePipe(string, time.Duration) error { return errNoPipeNamespace }
 

--- a/pkg/tasks/baseline/pipes_windows.go
+++ b/pkg/tasks/baseline/pipes_windows.go
@@ -58,28 +58,103 @@ func ListNamedPipes() ([]string, error) {
 	}
 }
 
-// ServePipe creates the named pipe name and holds it open for d, then exits —
-// the whole of a pipe decoy. A pipe exists only while a server holds a handle
-// to it, so nothing here waits for a client: the scan lists names and never
-// connects, exactly as the socket scan only stat()s. d is the belt of the
-// live-artifact lifecycle, so an unreachable cleanup is not a permanent leak.
-//
-// FILE_FLAG_FIRST_PIPE_INSTANCE is the soft-plant rule made atomic: if a real
-// service already serves this name, creation fails rather than adding an
-// instance beside it, so a decoy can never end up answering for a real tool.
-func ServePipe(name string, d time.Duration) error {
+const (
+	pipeInstanceBufSize = 512
+	// knockAttempts and knockInterval bound the expiry wake-up below. One knock is
+	// normally enough; repeating means a knock that itself fails cannot strand the
+	// server past its lifetime. The belt is a safety property, not an optimisation.
+	knockAttempts = 5
+	knockInterval = time.Second
+)
+
+// createPipeInstance creates one instance of name. first carries
+// FILE_FLAG_FIRST_PIPE_INSTANCE — the soft-plant rule made atomic: if a real service
+// already serves this name, creation fails rather than adding an instance beside it, so a
+// decoy can never end up answering for a real tool. Every instance AFTER ours must not ask
+// for it, because we hold one and it would fail against ourselves.
+func createPipeInstance(name string, first bool) (windows.Handle, error) {
 	p, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	mode := uint32(windows.PIPE_ACCESS_DUPLEX)
+	if first {
+		mode |= windows.FILE_FLAG_FIRST_PIPE_INSTANCE
+	}
+	h, err := windows.CreateNamedPipe(p, mode,
+		windows.PIPE_TYPE_BYTE, windows.PIPE_UNLIMITED_INSTANCES,
+		pipeInstanceBufSize, pipeInstanceBufSize, 0, nil)
+	if err != nil {
+		return windows.InvalidHandle, fmt.Errorf("creating pipe %s: %w", name, err)
+	}
+	return h, nil
+}
+
+// ServePipe serves name until d expires, answering each client with the pipe's own name and
+// then recycling the instance.
+//
+// This replaces a create-and-sleep server. The scan no longer only LISTS names: enumeration
+// was measured not to discriminate — 57 pipes confined and 57 unconfined on a Windows 11
+// host, 40 and 40 on a GitHub runner — because listing \\.\pipe\* is a directory read that a
+// restricted token does not change. Reachability is where the signal is, and it needs a
+// server that recycles rather than one that holds a single instance and sleeps.
+//
+// The token written back is the pipe's own name. A client that reads it has provably reached
+// THIS server rather than merely a name that resolved, which is the gap a redirected object
+// namespace — a server silo, an AppContainer — can otherwise hide.
+func ServePipe(name string, d time.Duration) error {
+	h, err := createPipeInstance(name, true)
 	if err != nil {
 		return err
 	}
-	h, err := windows.CreateNamedPipe(p,
-		windows.PIPE_ACCESS_DUPLEX|windows.FILE_FLAG_FIRST_PIPE_INSTANCE,
-		windows.PIPE_TYPE_BYTE, 1, 512, 512, 0, nil)
-	if err != nil {
-		return fmt.Errorf("creating pipe %s: %w", name, err)
+	defer func() {
+		if h != windows.InvalidHandle {
+			_ = windows.CloseHandle(h)
+		}
+	}()
+
+	// The belt has to fire while the loop below is blocked in ConnectNamedPipe. ServePort
+	// closes its listener to unblock Accept; CloseHandle on a handle with a synchronous
+	// ConnectNamedPipe in flight is not the documented equivalent, so the pipe answer is to
+	// become a client of our own pipe — the very client reachability already needs.
+	//
+	// It must be readPipeToken and not a bare open: a client that connects and never drains
+	// would leave FlushFileBuffers below waiting on it, which is the same wedge in a new place.
+	deadline := time.Now().Add(d)
+	go func() {
+		time.Sleep(d)
+		for range knockAttempts {
+			_, _ = readPipeToken(name)
+			time.Sleep(knockInterval)
+		}
+	}()
+
+	for time.Now().Before(deadline) {
+		// A client that arrived between creation and here is already connected, and
+		// ERROR_PIPE_CONNECTED says exactly that. It is success, not failure.
+		if cErr := windows.ConnectNamedPipe(h, nil); cErr != nil &&
+			!errors.Is(cErr, windows.ERROR_PIPE_CONNECTED) {
+			return nil // the instance went; there is nothing left to serve
+		}
+		var n uint32
+		_ = windows.WriteFile(h, []byte(name), &n, nil)
+		// Returns once the client has drained it, or once the client goes away.
+		// ponytail: a client that connects and never reads wedges the loop until the
+		// lifetime expires. The process dies then anyway, and the only client this private
+		// name ever has is ours.
+		_ = windows.FlushFileBuffers(h)
+
+		// Create the replacement BEFORE closing the served instance, so the name never
+		// lapses out of the namespace between clients — a scan enumerating at that instant
+		// must not miss it.
+		next, nErr := createPipeInstance(name, false)
+		_ = windows.CloseHandle(h)
+		h = windows.InvalidHandle // the defer must not close it a second time
+		if nErr != nil {
+			return nErr
+		}
+		h = next
 	}
-	defer windows.CloseHandle(h)
-	time.Sleep(d)
 	return nil
 }
 

--- a/pkg/tasks/baseline/pipes_windows.go
+++ b/pkg/tasks/baseline/pipes_windows.go
@@ -93,11 +93,11 @@ func createPipeInstance(name string, first bool) (windows.Handle, error) {
 // ServePipe serves name until d expires, answering each client with the pipe's own name and
 // then recycling the instance.
 //
-// This replaces a create-and-sleep server. The scan no longer only LISTS names: enumeration
-// was measured not to discriminate — 57 pipes confined and 57 unconfined on a Windows 11
-// host, 40 and 40 on a GitHub runner — because listing \\.\pipe\* is a directory read that a
-// restricted token does not change. Reachability is where the signal is, and it needs a
-// server that recycles rather than one that holds a single instance and sleeps.
+// This replaces a create-and-sleep server. The scan no longer only LISTS names, because
+// enumeration was measured not to discriminate: listing \\.\pipe\* is a directory read that a
+// restricted token does not change. Reachability is where the signal is, and it needs a server
+// that recycles rather than one that holds a single instance and sleeps. The measurement is in
+// docs/research/windows-named-pipe-enumeration.md section 4.
 //
 // The token written back is the pipe's own name. A client that reads it has provably reached
 // THIS server rather than merely a name that resolved, which is the gap a redirected object
@@ -120,21 +120,57 @@ func ServePipe(name string, d time.Duration) error {
 	//
 	// It must be readPipeToken and not a bare open: a client that connects and never drains
 	// would leave FlushFileBuffers below waiting on it, which is the same wedge in a new place.
+	// stopped closes as soon as the loop below leaves, and the knocker checks it between
+	// attempts. Without that check the knocks outlive our ownership of the name: the first
+	// one unblocks the loop, the loop closes its handle and returns, the name becomes free —
+	// and in production `name` is a real catalogue entry like \\.\pipe\docker_engine, so a
+	// later knock could open the actual Docker Desktop pipe. That is precisely the thing this
+	// package must never do, so the knocker is bounded by the server's own lifetime and not
+	// by an attempt count alone.
+	stopped := make(chan struct{})
+	defer close(stopped)
+
 	deadline := time.Now().Add(d)
 	go func() {
-		time.Sleep(d)
+		select {
+		case <-time.After(d):
+		case <-stopped:
+			return // already finished on its own; nothing to wake
+		}
 		for range knockAttempts {
+			select {
+			case <-stopped:
+				return
+			default:
+			}
 			_, _ = readPipeToken(name)
-			time.Sleep(knockInterval)
+			select {
+			case <-stopped:
+				return
+			case <-time.After(knockInterval):
+			}
 		}
 	}()
 
 	for time.Now().Before(deadline) {
 		// A client that arrived between creation and here is already connected, and
 		// ERROR_PIPE_CONNECTED says exactly that. It is success, not failure.
+		//
+		// Any other error retires this instance but must NOT retire the decoy: returning here
+		// would end the server before its lifetime while reporting success, and a scan would
+		// then read the absent name as a sandbox hiding it. Rebuild the instance and carry on;
+		// only a failure to rebuild is terminal.
 		if cErr := windows.ConnectNamedPipe(h, nil); cErr != nil &&
 			!errors.Is(cErr, windows.ERROR_PIPE_CONNECTED) {
-			return nil // the instance went; there is nothing left to serve
+			log.Debug().Err(cErr).Str("pipe", name).Msg("Pipe instance went; rebuilding it")
+			again, aErr := createPipeInstance(name, false)
+			_ = windows.CloseHandle(h)
+			h = windows.InvalidHandle
+			if aErr != nil {
+				return aErr
+			}
+			h = again
+			continue
 		}
 		var n uint32
 		_ = windows.WriteFile(h, []byte(name), &n, nil)

--- a/pkg/tasks/baseline/seed.go
+++ b/pkg/tasks/baseline/seed.go
@@ -111,6 +111,23 @@ func SeedTargets(targets []Target, recordPath string) (SeedResult, error) {
 		}
 		res.Planted++
 	}
+
+	// The reachability decoy, which is NOT a catalogue entry and must not become one. It
+	// stands in for no real tool, and that is the point: reachability is measured only
+	// against a name no real service can hold, because opening a real service's pipe is not
+	// passive. Same precedent as calibrate()'s control port — an instrument the probe plants
+	// for itself. See ReachPipeName.
+	//
+	// Off Windows seedPipe reports errNoPipeNamespace, which is not a skip: there is nothing
+	// there to skip.
+	if p, err := seedPipe(ReachPipeName); err == nil {
+		rec.Pipes = append(rec.Pipes, p)
+		res.Planted++
+	} else if !errors.Is(err, errNoPipeNamespace) {
+		log.Debug().Err(err).Str("pipe", ReachPipeName).Msg("Reachability decoy skipped")
+		res.Skipped++
+	}
+
 	return res, writeRecord(recordPath, rec)
 }
 

--- a/pkg/tasks/baseline/seed.go
+++ b/pkg/tasks/baseline/seed.go
@@ -118,14 +118,18 @@ func SeedTargets(targets []Target, recordPath string) (SeedResult, error) {
 	// passive. Same precedent as calibrate()'s control port — an instrument the probe plants
 	// for itself. See ReachPipeName.
 	//
-	// Off Windows seedPipe reports errNoPipeNamespace, which is not a skip: there is nothing
-	// there to skip.
+	// Deliberately absent from SeedResult. Planted and Skipped tally the CALLER's targets,
+	// and this is not one of them: counting it would make SeedTargets(nil, …) report one
+	// planted target for an empty list, and would let a concurrent run's still-live decoy —
+	// a correct soft-plant skip — read as a catalogue entry that could not be seeded. It
+	// still joins rec.Pipes, so cleanup removes it exactly like any other pipe decoy.
+	//
+	// Off Windows seedPipe reports errNoPipeNamespace: there is no namespace, so there is
+	// nothing to report either way.
 	if p, err := seedPipe(ReachPipeName); err == nil {
 		rec.Pipes = append(rec.Pipes, p)
-		res.Planted++
 	} else if !errors.Is(err, errNoPipeNamespace) {
-		log.Debug().Err(err).Str("pipe", ReachPipeName).Msg("Reachability decoy skipped")
-		res.Skipped++
+		log.Debug().Err(err).Str("pipe", ReachPipeName).Msg("Reachability decoy not planted")
 	}
 
 	return res, writeRecord(recordPath, rec)

--- a/pkg/tasks/baseline/seed_pipes_test.go
+++ b/pkg/tasks/baseline/seed_pipes_test.go
@@ -122,15 +122,26 @@ func TestSeedScanCleanupPipeRoundTrip(t *testing.T) {
 		t.Fatal("the decoy pipe is not reported after seeding")
 	}
 
+	// Two, not one: the catalogue decoy above plus the reachability decoy that SeedTargets
+	// plants for the probe itself.
+	//
+	// The asymmetry with SeedResult.Planted is deliberate and the two counts answer different
+	// questions. Planted and Skipped describe the CALLER's targets, so the probe's own
+	// instrument is excluded from them. This number answers "did you leave anything on my
+	// machine", where under-reporting is the harmful direction — every artifact cleanup took
+	// down is counted, whoever asked for it.
 	removed, err := CleanupSeeded(record)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if removed != 1 {
-		t.Errorf("cleanup removed %d, want 1", removed)
+	if removed != 2 {
+		t.Errorf("cleanup removed %d, want 2 (the catalogue decoy and the reachability decoy)", removed)
 	}
 	if pipeScanned(t, name) {
 		t.Fatal("the decoy pipe is still reported after cleanup")
+	}
+	if pipeScanned(t, ReachPipeName) {
+		t.Fatal("the reachability decoy is still reported after cleanup")
 	}
 	// Cleanup runs after every scan, including after a crashed one: a second pass
 	// over a record whose artifacts are gone is a no-op, not an error.

--- a/pkg/tasks/baseline/targets_ipc.go
+++ b/pkg/tasks/baseline/targets_ipc.go
@@ -3,7 +3,6 @@ package tasks
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -23,44 +22,6 @@ const maxUnixSocketPathLen = 104
 // than beside the enumerator because the catalogue is cross-platform: the
 // registry names Windows targets on every OS and lets the OS filter drop them.
 const pipePrefix = `\\.\pipe\`
-
-// errNoPipeNamespace is what the seeding half of the pipe seam reports off Windows. Declared
-// here rather than in the !windows file because portable code needs to recognise it: seeding
-// the reachability decoy must tell "there is no pipe namespace on this OS" apart from "the
-// plant failed", and only the second is a skip worth counting.
-var errNoPipeNamespace = errors.New("named pipes are Windows-only")
-
-// ReachPipeName is the ONLY pipe this probe ever opens as a client, and it is deliberately
-// NOT a catalogue entry.
-//
-// Opening a real service's pipe is not passive: it consumes a server instance, delivers a
-// connection event, and can hang a badly written server. So reachability is measured only
-// against a name no real service can hold.
-//
-// Why not the catalogue names, which are what an attacker would actually target. seedPipe
-// plants a decoy at one of those only when it is free, so at SCAN time `\\.\pipe\docker_engine`
-// is either our decoy or a live Docker Desktop — and the scan is a different process from the
-// seeder, with no way to tell which. Making it tell would mean reading the seed record, which
-// puts a SAFETY property behind a filesystem read the sandbox under test may block and whose
-// TMPDIR may differ. That is exactly backwards. Whether the catalogue names are visible is
-// already answered by named_pipe_detection; what reachability adds is whether an open succeeds,
-// and that question can be asked of any pipe — so ask it of the one where the answer costs
-// nobody anything.
-//
-// A name of this shape can only ever be ours: FILE_FLAG_FIRST_PIPE_INSTANCE means the seeder
-// holds it or nobody does. It is fixed rather than per-run for the same reason the record is
-// not consulted — seeder and scan share no state, and the only channel between them is that
-// record. Two concurrent probe runs collide benignly: the second seeder's plant is skipped and
-// the scan measures the first run's decoy, which is still the probe's own.
-const ReachPipeName = pipePrefix + "sandbox-probe-reachability-decoy"
-
-// reachControlPipeName is a name nothing ever serves: the calibration control, the same
-// instrument as calibrate()'s known-free loopback port. It says what "absent" looks like on
-// THIS host, so a not-found against the decoy is interpretable rather than merely
-// disappointing. Per-pid, so two concurrent runs cannot make each other's control real.
-func reachControlPipeName() string {
-	return pipePrefix + "sandbox-probe-control-" + strconv.Itoa(os.Getpid())
-}
 
 // decoyTag marks a seeded socket whose real-world counterpart is named per
 // instance (a random VS Code IPC uuid, a launchd Listeners dir, an ssh-agent

--- a/pkg/tasks/baseline/targets_ipc.go
+++ b/pkg/tasks/baseline/targets_ipc.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -22,6 +23,44 @@ const maxUnixSocketPathLen = 104
 // than beside the enumerator because the catalogue is cross-platform: the
 // registry names Windows targets on every OS and lets the OS filter drop them.
 const pipePrefix = `\\.\pipe\`
+
+// errNoPipeNamespace is what the seeding half of the pipe seam reports off Windows. Declared
+// here rather than in the !windows file because portable code needs to recognise it: seeding
+// the reachability decoy must tell "there is no pipe namespace on this OS" apart from "the
+// plant failed", and only the second is a skip worth counting.
+var errNoPipeNamespace = errors.New("named pipes are Windows-only")
+
+// ReachPipeName is the ONLY pipe this probe ever opens as a client, and it is deliberately
+// NOT a catalogue entry.
+//
+// Opening a real service's pipe is not passive: it consumes a server instance, delivers a
+// connection event, and can hang a badly written server. So reachability is measured only
+// against a name no real service can hold.
+//
+// Why not the catalogue names, which are what an attacker would actually target. seedPipe
+// plants a decoy at one of those only when it is free, so at SCAN time `\\.\pipe\docker_engine`
+// is either our decoy or a live Docker Desktop — and the scan is a different process from the
+// seeder, with no way to tell which. Making it tell would mean reading the seed record, which
+// puts a SAFETY property behind a filesystem read the sandbox under test may block and whose
+// TMPDIR may differ. That is exactly backwards. Whether the catalogue names are visible is
+// already answered by named_pipe_detection; what reachability adds is whether an open succeeds,
+// and that question can be asked of any pipe — so ask it of the one where the answer costs
+// nobody anything.
+//
+// A name of this shape can only ever be ours: FILE_FLAG_FIRST_PIPE_INSTANCE means the seeder
+// holds it or nobody does. It is fixed rather than per-run for the same reason the record is
+// not consulted — seeder and scan share no state, and the only channel between them is that
+// record. Two concurrent probe runs collide benignly: the second seeder's plant is skipped and
+// the scan measures the first run's decoy, which is still the probe's own.
+const ReachPipeName = pipePrefix + "sandbox-probe-reachability-decoy"
+
+// reachControlPipeName is a name nothing ever serves: the calibration control, the same
+// instrument as calibrate()'s known-free loopback port. It says what "absent" looks like on
+// THIS host, so a not-found against the decoy is interpretable rather than merely
+// disappointing. Per-pid, so two concurrent runs cannot make each other's control real.
+func reachControlPipeName() string {
+	return pipePrefix + "sandbox-probe-control-" + strconv.Itoa(os.Getpid())
+}
 
 // decoyTag marks a seeded socket whose real-world counterpart is named per
 // instance (a random VS Code IPC uuid, a launchd Listeners dir, an ssh-agent

--- a/pkg/tasks/baseline/token.go
+++ b/pkg/tasks/baseline/token.go
@@ -1,0 +1,13 @@
+//go:build !windows
+// +build !windows
+
+package tasks
+
+// A restricted token is a Windows access-token concept with no analogue elsewhere.
+//
+// The var exists on every platform, not just Windows, so the seam is stubbable from tests
+// that carry no build tag — which is what lets the false-positive table in
+// environment_test.go run on Linux and macOS too. Same shape as proc.go and landlock.go.
+var isRestrictedToken = isRestrictedTokenImpl
+
+func isRestrictedTokenImpl() bool { return false }

--- a/pkg/tasks/baseline/token_windows.go
+++ b/pkg/tasks/baseline/token_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+// +build windows
+
+package tasks
+
+import (
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/windows"
+)
+
+var isRestrictedToken = isRestrictedTokenImpl
+
+// isRestrictedTokenImpl reports whether this process runs under a token produced by
+// CreateRestrictedToken — the primitive behind Codex CLI's Windows sandbox
+// (`[windows] sandbox = "unelevated"`), Chromium's renderer sandbox, `psexec -l` and
+// others. It cannot say which of them built the token, which is why the caller reports it
+// as a mechanism and never as a wrapper name.
+//
+// This is deliberately the ONLY signal. Measured on a Windows 11 host against Codex CLI
+// 0.149.1, comparing the same user inside and outside the sandbox, the visible effects are:
+// BUILTIN\Administrators demoted to "use for deny only", every privilege but
+// SeChangeNotifyPrivilege stripped, and the integrity level unchanged at High.
+//
+// Both of the first two are also exactly what an ordinary non-elevated administrator's UAC
+// split token looks like, so keying off them would report every unconfined Windows desktop
+// as sandboxed and turn the `direct` baseline row red. IsTokenRestricted looks for
+// restricting SIDs, which UAC filtering does not add: false for a filtered token, true only
+// for a restricted one. Integrity is excluded on the measurement, not on principle — it is
+// identical on both sides and carries no information.
+//
+// A real TOKEN_QUERY handle rather than the GetCurrentProcessToken pseudo-handle:
+// pseudo-handle support is per-API and undocumented for this call, and this is not a bit to
+// be unsure about. Errors swallow to false, matching isSeatbelt and isChroot — emitting no
+// finding is recoverable, emitting a wrong one poisons every comparison the row appears in.
+func isRestrictedTokenImpl() bool {
+	var tok windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &tok); err != nil {
+		log.Warn().Err(err).Msg("OpenProcessToken failed; reporting no restricted token")
+		return false
+	}
+	defer func() { _ = tok.Close() }()
+
+	restricted, err := tok.IsRestricted()
+	if err != nil {
+		log.Warn().Err(err).Msg("IsTokenRestricted failed; reporting no restricted token")
+		return false
+	}
+	return restricted
+}

--- a/pkg/tasks/baseline_test.go
+++ b/pkg/tasks/baseline_test.go
@@ -478,3 +478,24 @@ func TestNamedPipeFindingValueShape(t *testing.T) {
 		t.Errorf("%s accepted a non-list value", NAMEDPIPEDETECTION)
 	}
 }
+
+// The three reachability finding types, and one deliberate omission.
+//
+// named_pipe_probe_status is map-shaped like local_probe_status and local_listeners, neither of
+// which is registered either: Validate falls through for anything unregistered, so declaring a
+// reflect.Type for it would reject the status map at runtime. The omission is a decision, and
+// this asserts it so nobody "completes" the map later and breaks the status finding.
+func TestNamedPipeReachFindingValueShapes(t *testing.T) {
+	for _, ft := range []string{NAMEDPIPEREACHABLE, NAMEDPIPECREATION} {
+		if got, want := expectedTypes[ft], expectedTypes[NAMEDPIPEDETECTION]; got != want {
+			t.Errorf("%s declared as %v, want %v (same shape as %s)", ft, got, want, NAMEDPIPEDETECTION)
+		}
+	}
+	if _, registered := expectedTypes[NAMEDPIPEPROBESTATUS]; registered {
+		t.Errorf("%s must stay out of expectedTypes: it is a status map, like %s, and registering "+
+			"a type for it would make Validate reject it", NAMEDPIPEPROBESTATUS, LOCALPROBESTATUS)
+	}
+	if _, registered := expectedTypes[LOCALPROBESTATUS]; registered {
+		t.Errorf("%s is the precedent this relies on and it has changed", LOCALPROBESTATUS)
+	}
+}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -61,10 +61,10 @@ const (
 	// NAMEDPIPEREACHABLE is the scored half of the Windows named-pipe measurement:
 	// pipes this process actually OPENED and round-tripped a token through.
 	//
-	// Enumeration was measured not to discriminate — 57 pipes confined and 57
-	// unconfined on a Windows 11 host, 40 and 40 on a GitHub runner — because
-	// listing \\.\pipe\* is a directory read a restricted token does not change.
-	// This is where the signal is.
+	// Enumeration was measured not to discriminate: listing \\.\pipe\* is a
+	// directory read, which a restricted token does not change, so the name list
+	// is identical either side of the boundary. This is where the signal is.
+	// See docs/research/windows-named-pipe-enumeration.md section 4.
 	//
 	// NEVER a catalogue name. Only the probe's own seeded decoy, because opening a
 	// real service's pipe consumes a server instance and delivers a connection

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -57,6 +57,32 @@ const (
 	// It is what makes "could not measure" distinguishable from "measured
 	// zero", which is the root of the false-blocked class of bug.
 	LOCALPROBESTATUS = "local_probe_status"
+
+	// NAMEDPIPEREACHABLE is the scored half of the Windows named-pipe measurement:
+	// pipes this process actually OPENED and round-tripped a token through.
+	//
+	// Enumeration was measured not to discriminate — 57 pipes confined and 57
+	// unconfined on a Windows 11 host, 40 and 40 on a GitHub runner — because
+	// listing \\.\pipe\* is a directory read a restricted token does not change.
+	// This is where the signal is.
+	//
+	// NEVER a catalogue name. Only the probe's own seeded decoy, because opening a
+	// real service's pipe consumes a server instance and delivers a connection
+	// event to somebody else's software.
+	NAMEDPIPEREACHABLE = "named_pipe_reachable"
+
+	// NAMEDPIPECREATION names the pipe the probe created and immediately destroyed.
+	// Enumerating, opening and creating are three different operations against three
+	// different access checks, and a filter can allow one and deny another — so
+	// creation is measured rather than inferred from the other two.
+	NAMEDPIPECREATION = "named_pipe_creation"
+
+	// NAMEDPIPEPROBESTATUS says how the reachability measurement went: the control
+	// against a name nothing serves, whether the namespace was readable, whether the
+	// decoy was enumerated at all, and the per-pipe outcome behind the scored list.
+	// Same job as LOCALPROBESTATUS — telling "could not measure" from "measured
+	// zero".
+	NAMEDPIPEPROBESTATUS = "named_pipe_probe_status"
 )
 
 var expectedTypes = map[string]reflect.Type{
@@ -69,14 +95,19 @@ var expectedTypes = map[string]reflect.Type{
 	PROXYDETECTION:            reflect.TypeOf(&models.ProxyConfig{}),
 	UNIXSOCKETDETECTION:       reflect.TypeOf([]string{}),
 	NAMEDPIPEDETECTION:        reflect.TypeOf([]string{}),
-	PROCESSDETECTION:          reflect.TypeOf(&models.Process{}),
-	PARENTPROCESSDETECTION:    reflect.TypeOf(&models.Process{}),
-	MOUNTEDVOLUMESDETECTION:   reflect.TypeOf([]string{}),
-	USERCONTEXTDETECTION:      reflect.TypeOf(&models.UserIdentity{}),
-	HOSTNAMEDETECTION:         reflect.TypeOf(""),
-	ENVIRONMENTDETECTION:      reflect.TypeOf(&models.HostEnvironment{}),
-	ENVSECRETDETECTION:        reflect.TypeOf(&models.EnvFinding{}),
-	SANDBOXDETECTION:          reflect.TypeOf(""),
+	NAMEDPIPEREACHABLE:        reflect.TypeOf([]string{}),
+	NAMEDPIPECREATION:         reflect.TypeOf([]string{}),
+	// NAMEDPIPEPROBESTATUS is deliberately absent: it is map-shaped, exactly like
+	// LOCALPROBESTATUS and LOCALLISTENERS, and Validate falls through for anything
+	// unregistered. Asserted in a test so the omission reads as a decision.
+	PROCESSDETECTION:        reflect.TypeOf(&models.Process{}),
+	PARENTPROCESSDETECTION:  reflect.TypeOf(&models.Process{}),
+	MOUNTEDVOLUMESDETECTION: reflect.TypeOf([]string{}),
+	USERCONTEXTDETECTION:    reflect.TypeOf(&models.UserIdentity{}),
+	HOSTNAMEDETECTION:       reflect.TypeOf(""),
+	ENVIRONMENTDETECTION:    reflect.TypeOf(&models.HostEnvironment{}),
+	ENVSECRETDETECTION:      reflect.TypeOf(&models.EnvFinding{}),
+	SANDBOXDETECTION:        reflect.TypeOf(""),
 }
 
 // Registry with wrapper functions


### PR DESCRIPTION
Windows rows in the comparison matrix have never measured anything. This makes them able to.

Both changes were verified on a real Windows 11 host and a GitHub `windows-latest` runner, not inferred.

## The problem, measured

**Enumeration does not discriminate.** The probe confined by Codex CLI's Windows sandbox versus unconfined, same machine, same session:

| | pipes confined | pipes unconfined |
|---|---|---|
| Win11 VM | 57 | 57 |
| CI runner | 40 | 40 (unconfined `direct` baseline 38) |

A restricted token changes *access checks*; enumerating `\\.\pipe\*` is a directory read. So `named_pipe_detection` cannot tell a sandboxed Windows agent from an unsandboxed one, and never could — which is why that capability has produced no comparison data since it was built.

**And the probe could not see the sandbox at all.** A demonstrably confined run emitted `sandbox_detection=[]`, because every branch of `GetContainerRuntime` is `/proc`-shaped and `ActiveMechanisms` reads only `/proc/self/status`.

## Detection: one signal, chosen to avoid a specific trap

`IsTokenRestricted()`, from a dependency already imported. Nothing new is added.

Comparing the same user inside and outside the sandbox, the visible effects are: `BUILTIN\Administrators` demoted to **"Group used for deny only"**, privileges collapsed from about twenty to **only `SeChangeNotifyPrivilege`**, integrity **unchanged** at High.

The first two are also exactly what an ordinary non-elevated administrator's UAC split token looks like. A detector keyed on either would report **every unconfined Windows desktop as sandboxed** — including the `direct` baseline row, whose entire job is to be the unconfined comparison. `IsTokenRestricted` looks for restricting SIDs, which UAC filtering does not add. Integrity is excluded on the measurement rather than on principle.

Emitted as a **mechanism**, not a wrapper name: a restricted token is kernel-attested, and it cannot say which tool built it — Codex, Chromium's renderer and `psexec -l` all produce one. It also reaches the badge as `RuntimeUnknown`, which is not optional: `sandboxOf()` reports `"none"` for a row whose only values are mechanisms, so without it a correctly detected confined run would render as **unsandboxed**.

`RuntimeUnknown` rather than a new enum value, deliberately — a new value needs a switch case, and `RuntimeBubblewrap` is this repo's own proof of what happens when one is missed.

Verified on the VM:

```
UNCONFINED sandbox_detection: (empty)
CONFINED   sandbox_detection: unknown[Container/wrapper runtime],
                              restricted-token[Active kernel enforcement mechanism]
```

## Reachability: only ever against our own decoy

Opening a real service's pipe is **not passive** — it consumes a server instance, delivers a connection event, and can hang a badly written server. This runs on real laptops. Reading a foreign pipe's DACL by name is *also* a client connect, so it is not a passive alternative either.

So `ReachPipeName` is a fixed private name and deliberately **not** a catalogue entry. At scan time `\\.\pipe\docker_engine` is either our decoy or a live Docker Desktop, and the scan is a different process from the seeder with no way to tell. Making it tell would put a safety property behind a filesystem read the sandbox under test may block.

`ImpersonateNamedPipeClient` is never implemented. That is the attack.

Three things this needed:

- **`ServePipe` becomes a real server.** `nMaxInstances=1` with no `ConnectNamedPipe` meant one client consumed the only instance and it was never recycled. Needs both `PIPE_UNLIMITED_INSTANCES` and an accept loop, and creates the replacement instance *before* closing the served one so the name never lapses out of the namespace mid-scan.
- **The self-expiry needed care.** `ServePort` unblocks `Accept` by closing its listener; that has no documented equivalent with a synchronous `ConnectNamedPipe` in flight. At expiry the server becomes a client of its own pipe — and must *read*, not merely connect, or `FlushFileBuffers` wedges in a new place. `TestSeededPipeExpiresWithNoCleanup` used to pass trivially against `time.Sleep(d)`; it is now the only thing between a blocked `ConnectNamedPipe` and a decoy outliving every scan.
- **A separate Win32 classifier.** `errno_windows.go` matches Winsock numbers; a `CreateFile` failure carries a low Win32 code and the two spaces do not collide — so `classify()` reports `ERROR_ACCESS_DENIED`, the single most interesting result, as a probe malfunction. A test asserts both classifiers *disagree* on that code, so they cannot be quietly merged.

The round trip is required rather than optional: a successful open proves a name resolved and an access check passed, not *which object* answered, and Windows redirects object namespaces for exactly the container-shaped isolation being measured.

## What the VM caught that the design did not

Three existing tests failed on first run. Each was a design question, not a stale expectation.

I had counted the reachability decoy in `SeedResult.Planted`. `Planted` and `Skipped` describe the **caller's** targets, so counting the probe's own instrument made `SeedTargets(nil, …)` report a planted target for an empty list, and let a correct soft-plant skip read as a catalogue entry that could not be seeded. Now excluded from both.

`CleanupSeeded`'s count goes the other way, deliberately: it answers *did anything get left on my machine*, where under-reporting is the harmful direction. Every artifact taken down is counted. The round-trip test now expects two and additionally asserts the reachability decoy is gone.

Updating those three tests' numbers instead would have shipped a `SeedResult` that misdescribes what the caller asked for, invisibly.

## Verification

`go build` and `go test` pass on macOS and Windows; `GOOS=windows go vet` clean. The full Windows suite was run on a real Win11 host — including the tests that only execute there.

`TestReachabilityNeverTargetsACatalogueName` carries **no build tag** on purpose, so a contributor who cannot run a line of the Windows code can still break the safety invariant and see it fail.
