### PR TITLE
fix(release): stop a commit's prose bumping the major, and guard the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,34 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # A tag whose major disagrees with the module path is unresolvable: the Go proxy
+      # refuses it, so the release publishes binaries nobody can `go get`. It has happened
+      # twice — every tag from v4.8.2 to v5.2.1, and v7.0.1 on 2026-08-24, the latter from a
+      # commit whose subject was fixing the module path and whose body contained the word
+      # "major". semver.yaml's `force.major` is a floor and does not prevent it, and a comment
+      # is not a guard, so this fails the release before anything is tagged or published.
+      #
+      # An unsuffixed module path (v0/v1) has no major to check and is skipped.
+      - name: Check the computed major matches the module path
+        run: |
+          set -euo pipefail
+          computed="${{ needs.version.outputs.semver }}"
+          major="${computed%%.*}"
+          modpath="$(go list -m)"
+          suffix="${modpath##*/}"
+          if [[ ! "$suffix" =~ ^v[0-9]+$ ]]; then
+            echo "module path $modpath carries no major suffix; nothing to check"
+            exit 0
+          fi
+          if [ "v$major" != "$suffix" ]; then
+            echo "::error::computed version v$computed has major v$major, but the module is $modpath."
+            echo "::error::The Go proxy would reject that tag. Either the commit wording bumped the"
+            echo "::error::major by accident (see semver.yaml), or the module path must be renamed in"
+            echo "::error::the same change. Not tagging."
+            exit 1
+          fi
+          echo "v$major matches $suffix"
+
       - name: Create local release tag
         run: |
           git tag "v${{ needs.version.outputs.semver }}"

--- a/semver.yaml
+++ b/semver.yaml
@@ -3,6 +3,11 @@ version: 1
 # proxy rejects any tag whose major disagrees with the module path, which is
 # how every tag from v4.8.2 to v5.2.1 became unresolvable. Bumping the major
 # here means renaming the module path in the same commit.
+#
+# `force` is a FLOOR, not a ceiling. It does not stop the wording rules below
+# from bumping the major past it — v7.0.1 was cut that way on 2026-08-24 and had
+# to be deleted. The release workflow now checks the computed major against
+# go.mod before tagging, because a comment is not a guard.
 force:
   major: 6
   minor: 1
@@ -22,5 +27,10 @@ wording:
     - improve
     - feature
   major:
+    # Deliberately just "breaking". The bare word "major" used to be here and it
+    # is a trap in THIS repository: the module path carries a major-version
+    # suffix, so ordinary prose about it — "no major-version suffix", "whose
+    # major disagrees" — appears in commit messages routinely. That is exactly
+    # what cut the dead v7.0.1 tag, from a commit whose whole subject was fixing
+    # the module path.
     - breaking
-    - major


### PR DESCRIPTION
`v7.0.1` was cut on 24 August against a module declaring `/v6`. The Go proxy will never serve it — `/v7` is 404 and `/v6` stops at `v6.7.3` — so that release published nine binaries nobody can `go get`. It is the same failure that killed every tag from `v4.8.2` to `v5.2.1`.

## The cause is a trap specific to this repository

`semver.yaml` listed the bare word **`major`** as a major-bump keyword. The module path carries a major-version *suffix*, so ordinary prose about it turns up in commit messages constantly.

The commit that triggered it was **#58 — whose entire subject was correcting the module path**, and whose body reads "no **major**-version suffix". A change fixing the module path broke the module path.

`force.major: 6` did not prevent it. It is a floor, not a ceiling.

## Two parts

Removing the keyword alone would leave the same class of accident available to any future wording rule, so:

1. **The keyword goes.** `breaking` stays and is unambiguous. `major` cannot be used here without colliding with the domain this project talks about all day.
2. **The release workflow now checks the computed major against the module path** and fails before anything is tagged or published. The warning comment about this hazard was already sitting in `semver.yaml` and did not help — a comment is not a guard. An unsuffixed module path has no major to check and is skipped.

## Checked

Against both real cases:

```
v6.8.0 + /v6 -> PASS
v7.0.1 + /v6 -> FAIL   (the tag that should never have existed)
v1.2.3 + unsuffixed -> skip
```

## Still to do, separately

The dead `v7.0.1` release and tag need deleting — this change stops another being created but does not remove the existing one. Until it is gone, the generator computes from it and every future tag stays in the dead `/v7` line.
