### PR TITLE
fix(release): derive the major from a sentinel, never from English prose

### DIFF
--- a/semver.yaml
+++ b/semver.yaml
@@ -27,10 +27,19 @@ wording:
     - improve
     - feature
   major:
-    # Deliberately just "breaking". The bare word "major" used to be here and it
-    # is a trap in THIS repository: the module path carries a major-version
-    # suffix, so ordinary prose about it — "no major-version suffix", "whose
-    # major disagrees" — appears in commit messages routinely. That is exactly
-    # what cut the dead v7.0.1 tag, from a commit whose whole subject was fixing
-    # the module path.
-    - breaking
+    # A sentinel, not an English word, and deliberately one nobody types by accident.
+    #
+    # Both obvious keywords are landmines in THIS repository, and both have fired.
+    # "major" cut the dead v7.0.1 tag, from a commit whose subject was fixing the
+    # module path and whose body said "no major-version suffix". Removing it was not
+    # enough: "breaking" then fired on ordinary prose — two commits from July say
+    # "breaking the git operation", and the very commit that removed "major" said
+    # "'breaking' stays and is unambiguous". It was not unambiguous.
+    #
+    # The deeper reason neither belongs here: a major bump in this repository REQUIRES
+    # renaming the module path in the same change, because the Go proxy rejects any tag
+    # whose major disagrees with the /vN suffix. That is a deliberate, coordinated act.
+    # Nobody performs it by accident, so nothing should trigger it by accident. With no
+    # English keyword here the major can only move by editing force.major below, which
+    # is the level of intent the change actually warrants.
+    - SEMVER-MAJOR-BUMP


### PR DESCRIPTION
The guard from #60 worked on its first run — it refused to tag `v7.0.1` against a module declaring `/v6`, so nothing dead was published. But the version still computed as `v7`, which means my diagnosis in #60 was incomplete.

## It was incomplete, and in an instructive way

Removing one keyword left the other, and the other is just as ordinary a word.

```
commits in history containing "major":    9
commits in history containing "breaking": 3
commits containing the new sentinel:      0
```

The generator reads the **whole history**, so all twelve were standing triggers. Among them:

- Two from July that simply say *"breaking the git operation"* — ordinary English, nothing to do with versioning.
- **The #60 commit itself**, which said `'breaking' stays and is unambiguous`. It was not unambiguous. The change that removed the first landmine stepped on the second while explaining it.

## Why neither word belongs there

This is structural, not a matter of choosing better words.

A major bump in this repository **requires renaming the module path in the same change**, because the Go proxy rejects any tag whose major disagrees with the `/vN` suffix. That is a deliberate, coordinated act. Nobody does it by accident — so nothing should trigger it by accident.

The list now holds one sentinel that appears in no commit here and is not a word anyone types while describing a bug. The major can move only by editing `force.major`, which is the level of intent the change actually warrants.

## The guard stays

It is what turned this from a published dead release into a failed build, and it is what will catch the next thing I have not thought of.

## Expected after merge

`v6.7.4`, with the guard printing `v6 matches v6`.
