### PR TITLE
feat(windows): detect an AppContainer, so Copilot's sandbox stops reading as absent

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -118,21 +118,38 @@ must know which one it is contributing to:
   ancestry, markers and, as a last resort, a restricted user namespace's ID
   map. Treat it as a hypothesis, not an attested fact.
 - A **mechanism** (`seccomp-filter`, `no-new-privs`, `landlock`,
-  `user-namespace`, `restricted-token`, …) is *kernel-attested*: read directly
-  off a kernel interface (`/proc/self/status`, the uid_map, `IsTokenRestricted`
-  on Windows), true regardless of whether the wrapper name resolved. Mechanisms
-  are emitted alongside the badge, never folded into it.
+  `user-namespace`, `restricted-token`, `app-container`, …) is
+  *kernel-attested*: read directly off a kernel interface
+  (`/proc/self/status`, the uid_map, `IsTokenRestricted` or
+  `TokenIsAppContainer` on Windows), true regardless of whether the wrapper
+  name resolved. Mechanisms are emitted alongside the badge, never folded into
+  it.
 
-`restricted-token` is the Windows mechanism, and it is deliberately the *only*
-Windows signal. Measured against Codex CLI 0.149.1, a sandboxed process has
-`BUILTIN\Administrators` demoted to "use for deny only" and every privilege but
-`SeChangeNotifyPrivilege` stripped — and so does an ordinary non-elevated
-administrator's UAC split token, which is every Windows desktop. Detecting
-either of those would report the unconfined baseline as sandboxed.
-`IsTokenRestricted` looks for restricting SIDs, which UAC filtering does not
-add. Integrity level is not a signal either: measured High both inside and
-outside. Do not "improve" this detector by adding the group or privilege
-checks.
+There are exactly two Windows mechanisms, and each reads exactly one token bit.
+
+`restricted-token` is Codex CLI's Windows sandbox. Measured against Codex CLI
+0.149.1, a sandboxed process has `BUILTIN\Administrators` demoted to "use for
+deny only" and every privilege but `SeChangeNotifyPrivilege` stripped — and so
+does an ordinary non-elevated administrator's UAC split token, which is every
+Windows desktop. Detecting either of those would report the unconfined baseline
+as sandboxed. `IsTokenRestricted` looks for restricting SIDs, which UAC
+filtering does not add. Integrity level is not a signal either: measured High
+both inside and outside. Do not "improve" this detector by adding the group or
+privilege checks.
+
+`app-container` is GitHub Copilot CLI's Windows sandbox, which is Microsoft
+Execution Containers (MXC) on its ProcessContainer backend. MXC's Windows
+runner always sets the `app_container` field of the SandboxSpec it hands to
+`Experimental_CreateProcessInSandbox`, so the AppContainer is the one part of
+that spec a caller cannot turn off. Every other control in it — the
+`JOB_OBJECT_UILIMIT` flags, the win32k system-call mitigation, least-privilege,
+the integrity level — is policy the caller chooses, so none of them is safe to
+key off. Do not add them.
+
+The two are separate values rather than one "windows-sandbox", because the
+primitives are independent: MXC builds an AppContainer without a restricted
+token, and Codex builds a restricted token without an AppContainer. Keeping
+them apart is what lets the data tell the two sandboxes apart.
 
 The wrapper-name chain has two tiers, and a new detector belongs in whichever
 one matches what it can actually claim.
@@ -142,7 +159,7 @@ one matches what it can actually claim.
   *for naming*, tried only after every more specific runtime detector has had
   its chance to claim the run.
 - A detector that proves **enforcement exists but cannot name it** goes in the
-  generic-fallback tier at the very bottom, alongside no-new-privs and the
-  Windows restricted-token check, and returns `RuntimeUnknown`. Placing it
+  generic-fallback tier at the very bottom, alongside no-new-privs and the two
+  Windows token checks, and returns `RuntimeUnknown`. Placing it
   higher would let it outrank a detector that *can* name the tool, which is a
   worse answer, not a better one.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Each row below is a `finding_type` string you will see in `report.json`, what it
 | `hostname_detection` | system hostname | "Does the sandbox leak the host identity?" |
 | `env_secret_detection` | environment variables whose value is secret-shaped, by name and why they matched (never the value) | "Which credentials were handed to the agent's process in the first place?" |
 | `environment_detection` | host kernel release/version + OS release | "Which kernel/OS produced this result?" (so reports stay comparable across upgrades) |
-| `sandbox_detection` | one **wrapper name** — an inferred best guess at the tool (Docker, Podman, LXC, Firejail, Bubblewrap, gVisor, systemd-nspawn, WSL, OpenVZ, Seatbelt, Landlock, AppArmor, chroot) — plus zero or more kernel-attested **mechanisms** (`seccomp-filter`, `seccomp-notify`, `seccomp-strict`, `no-new-privs`, `landlock`, `user-namespace`, `restricted-token`) | "Is there *any* enforcement at all, and what kind?" |
+| `sandbox_detection` | one **wrapper name** — an inferred best guess at the tool (Docker, Podman, LXC, Firejail, Bubblewrap, gVisor, systemd-nspawn, WSL, OpenVZ, Seatbelt, Landlock, AppArmor, chroot) — plus zero or more kernel-attested **mechanisms** (`seccomp-filter`, `seccomp-notify`, `seccomp-strict`, `no-new-privs`, `landlock`, `user-namespace`, `restricted-token`, `app-container`) | "Is there *any* enforcement at all, and what kind?" |
 
 The wrapper name is a hypothesis; a mechanism is read straight off a kernel interface and is a fact. See [`CONTEXT.md`](./CONTEXT.md) for the distinction and why it matters when adding a detector.
 

--- a/docs/adr/0005-detect-appcontainer-as-a-windows-mechanism.md
+++ b/docs/adr/0005-detect-appcontainer-as-a-windows-mechanism.md
@@ -111,8 +111,16 @@ boolean.
 
 Verified: cross-compiles and vets for `windows/amd64`; the portable table test
 covers all four combinations of the two token bools, proving each mechanism is
-a pure function of its own bit; `TestIsAppContainerFalseForAnOrdinaryProcess`
-runs the real API on a Windows runner and asserts the negative.
+a pure function of its own bit.
+
+`TestIsAppContainerFalseForAnOrdinaryProcess` runs the real API on a Windows
+runner, and it requires the syscall to **succeed** rather than only checking
+that the answer is false. Asserting on `isAppContainerImpl` alone would pass
+identically whether the class number is right and the answer is genuinely
+false, or the call failed outright and nothing was measured — the same
+absent-versus-empty confusion the findings themselves avoid. It passed on
+`windows-latest`, so class 29 and the read path are measured facts, not
+assumptions.
 
 **Not verified: the positive case against a live MXC ProcessContainer.** The
 evidence that `app_container` is always set is MXC's own source, not a

--- a/docs/adr/0005-detect-appcontainer-as-a-windows-mechanism.md
+++ b/docs/adr/0005-detect-appcontainer-as-a-windows-mechanism.md
@@ -1,0 +1,121 @@
+# 5. Detect an AppContainer as the second Windows mechanism
+
+Date: 2026-08-25
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0004 gave the probe one Windows signal, `restricted-token`, which reads
+`IsTokenRestricted` and detects Codex CLI's Windows sandbox. That detector is
+correct and stays as it is.
+
+It does not see GitHub Copilot CLI's sandbox. Measured on a Windows 11 host,
+a probe run demonstrably confined by Copilot emitted `sandbox_detection: []`
+and produced results identical to the unconfined run beside it. The probe was
+blind to the enforcement, so the pair proved nothing.
+
+ADR numbering is shared with `controlplaneio/sandbox-probe-reports`, which
+holds 0001, 0003 and 0004. This is 0005.
+
+### What Copilot's sandbox actually is
+
+Copilot CLI's sandbox is Microsoft Execution Containers (MXC), one abstraction
+over three OS backends: Seatbelt on macOS, bubblewrap on Linux and
+**ProcessContainer** on Windows. The first two are already mechanisms the probe
+detects, which is why only the Windows backend was invisible.
+
+The name "ProcessContainer" suggests a Windows Server Silo. It is not one.
+MXC's Windows runner calls `Experimental_CreateProcessInSandbox` in
+`processmodel.dll`, passing a `SandboxSpec` FlatBuffer. Its `BaseContainerRunner`
+always sets that spec's `app_container` field to true. The isolation is an
+**AppContainer**, with job-object UI limits and process mitigations layered on
+top.
+
+### Why one bit, and which one
+
+The `SandboxSpec` carries several things the probe could read:
+
+| spec field | observable as | usable? |
+| :--- | :--- | :--- |
+| `app_container` | `TokenIsAppContainer` | **yes — always true** |
+| `ui_restrictions` | `JOB_OBJECT_UILIMIT_*` flags | no — caller's policy |
+| `disallow_win32k_system_calls` | process mitigation policy | no — caller's policy |
+| `least_privilege` | stripped privilege set | no — caller's policy, and UAC-shaped |
+| integrity level | `TokenIntegrityLevel` | no — caller's policy |
+
+Only `app_container` is an invariant. Every other field is policy a caller
+chooses, so its absence would prove nothing and a detector built on it would
+report a real sandbox as absent whenever the caller turned that field off. The
+same "read exactly one attested bit" discipline ADR 0004 applied to
+`restricted-token` applies here, for the same reason.
+
+`least_privilege` deserves the explicit note: it produces the deny-only groups
+and stripped privileges that ADR 0004 already rejected, because an ordinary
+non-elevated administrator's UAC split token is identical on both. It was
+rejected once and is rejected again here.
+
+## Decision
+
+Add `app-container` as a second Windows **mechanism**, read from
+`TokenIsAppContainer` on a real `TOKEN_QUERY` handle. It reuses the existing
+`token.go` / `token_windows.go` seam rather than adding files, because it is
+the same kind of fact: what this process's access token says about its own
+confinement.
+
+Like `restricted-token`, it also returns `RuntimeUnknown` from
+`GetContainerRuntime`'s generic-fallback tier. That is not optional: the site's
+`sandboxOf()` reports `"none"` for a row whose only values are mechanisms, so a
+correctly detected confined run would otherwise render as unsandboxed.
+
+It needs its own line in that tier rather than extending the restricted-token
+branch. An AppContainer carries no restricting SIDs, so `IsTokenRestricted` is
+false inside one and the existing branch does not fire.
+
+### Two values, not one
+
+`restricted-token` and `app-container` stay separate rather than collapsing
+into one `windows-sandbox`. The primitives are independent — MXC builds an
+AppContainer without calling `CreateRestrictedToken`, and Codex builds a
+restricted token without an AppContainer — so keeping them apart is exactly
+what lets the published data tell the two vendors' Windows sandboxes apart.
+Collapsing them would throw that away to save one string.
+
+### A mechanism, never a badge
+
+An AppContainer token cannot say who created it. Store apps, Chromium's
+renderer processes and Defender Application Guard all produce one. Naming
+Copilot from this bit would repeat the `srt (linux)` mistake, so it is emitted
+alongside the badge and never folded into it.
+
+## Consequences
+
+The false-positive risk here is **lower** than the restricted-token detector's,
+not higher. A restricted token is nearly the shape of an ordinary UAC split
+token, which is why ADR 0004 had to argue carefully about what not to read. An
+AppContainer has no ambient analogue: a normal console process on a normal
+desktop is not in one, and only something that deliberately built an
+AppContainer can put the probe inside it.
+
+`TokenIsAppContainer` is `TOKEN_INFORMATION_CLASS` 29 and `x/sys/windows` does
+not export it — its iota run stops one short, at `TokenLogonSid`. The constant
+is therefore written out here, and a test pins the literal against
+`windows.TokenLogonSid+1`, so the two independent sources have to agree. A
+future `x/sys` that inserts a class into that run fails the test instead of the
+probe silently querying a different token property and reading the result as a
+boolean.
+
+### What is verified, and what is not
+
+Verified: cross-compiles and vets for `windows/amd64`; the portable table test
+covers all four combinations of the two token bools, proving each mechanism is
+a pure function of its own bit; `TestIsAppContainerFalseForAnOrdinaryProcess`
+runs the real API on a Windows runner and asserts the negative.
+
+**Not verified: the positive case against a live MXC ProcessContainer.** The
+evidence that `app_container` is always set is MXC's own source, not a
+measurement of a running sandbox. The Windows `copilot-sandbox` matrix row is
+what will close that, and until it runs green the positive case rests on
+reading the vendor's code rather than on observing the vendor's behaviour.

--- a/pkg/tasks/baseline/environment.go
+++ b/pkg/tasks/baseline/environment.go
@@ -319,6 +319,14 @@ func GetContainerRuntime(tgid, pid int) ContainerRuntime {
 		return RuntimeUnknown
 	}
 
+	// An AppContainer says the same thing about Copilot CLI's Windows sandbox that the
+	// restricted token above says about Codex's: confined, and not nameable from the token.
+	// It needs its own line because the two primitives are independent — MXC builds an
+	// AppContainer without calling CreateRestrictedToken, so the check above does not cover it.
+	if isAppContainer() {
+		return RuntimeUnknown
+	}
+
 	return identifiedRuntime
 }
 
@@ -392,6 +400,17 @@ func ActiveMechanisms() []string {
 	// Windows desktop as sandboxed. See isRestrictedTokenImpl for the measurement.
 	if isRestrictedToken() {
 		mechanisms = append(mechanisms, "restricted-token")
+	}
+
+	// TokenIsAppContainer — the primitive behind Copilot CLI's Windows sandbox (MXC's
+	// ProcessContainer backend), kernel-attested in the same way.
+	//
+	// Separate from restricted-token rather than folded into one "windows-sandbox" value,
+	// because they are different primitives and a token can carry either, both or neither.
+	// Keeping them apart is exactly what lets the data tell Codex's Windows sandbox from
+	// Copilot's. See isAppContainerImpl for why this is the only bit read.
+	if isAppContainer() {
+		mechanisms = append(mechanisms, "app-container")
 	}
 
 	// /proc/self/status fields (all kernels that have the feature export it here)

--- a/pkg/tasks/baseline/environment_test.go
+++ b/pkg/tasks/baseline/environment_test.go
@@ -269,38 +269,46 @@ func TestGetContainerRuntimeSystemdContainerMarker(t *testing.T) {
 	}
 }
 
-// TestActiveMechanismsRestrictedToken pins "restricted-token" to the IsTokenRestricted bit and
-// to nothing else.
+// TestActiveMechanismsWindowsTokenBits pins "restricted-token" to the IsTokenRestricted bit and
+// "app-container" to the TokenIsAppContainer bit, each to nothing else.
 //
 // The case that matters is the false one. A non-elevated administrator's UAC split token has
 // deny-only BUILTIN\Administrators and a single privilege — exactly the shape measured inside
 // Codex CLI's Windows sandbox — and must NOT be reported. Making the emitted set a pure function
-// of one bool is what guarantees that, and this table is the proof: no group, privilege or
+// of the token bools is what guarantees that, and this table is the proof: no group, privilege or
 // integrity signal reaches the finding, because none of them is an input to any code path.
 //
 // readFile is stubbed to fail so the assertion covers the whole returned list on a Linux runner
 // too, where a container's real NoNewPrivs bit would otherwise leak in.
-func TestActiveMechanismsRestrictedToken(t *testing.T) {
-	origToken, origRead := isRestrictedToken, readFile
-	t.Cleanup(func() { isRestrictedToken, readFile = origToken, origRead })
+func TestActiveMechanismsWindowsTokenBits(t *testing.T) {
+	origToken, origAppC, origRead := isRestrictedToken, isAppContainer, readFile
+	t.Cleanup(func() { isRestrictedToken, isAppContainer, readFile = origToken, origAppC, origRead })
 	readFile = func(string) ([]byte, error) { return nil, fmt.Errorf("file not found") }
 
+	// All four combinations, because the two primitives are independent: MXC builds an
+	// AppContainer without a restricted token, Codex builds a restricted token without an
+	// AppContainer, and a wrapper could do both. A table that only walked one axis would let
+	// one bit mask the other.
 	for _, tt := range []struct {
-		name       string
-		restricted bool
-		want       []string
+		name         string
+		restricted   bool
+		appContainer bool
+		want         []string
 	}{
-		{"restricted token", true, []string{"restricted-token"}},
-		{"unrestricted token", false, nil},
+		{"neither", false, false, nil},
+		{"restricted token only", true, false, []string{"restricted-token"}},
+		{"app container only", false, true, []string{"app-container"}},
+		{"both", true, true, []string{"restricted-token", "app-container"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			isRestrictedToken = func() bool { return tt.restricted }
+			isAppContainer = func() bool { return tt.appContainer }
 			assert.Equal(t, tt.want, ActiveMechanisms())
 		})
 	}
 }
 
-// A restricted token must also reach the wrapper badge, as RuntimeUnknown.
+// Each Windows token bit must also reach the wrapper badge, as RuntimeUnknown.
 //
 // Without it the site's sandboxOf() reports "none" for a row whose only values are mechanisms,
 // so a correctly detected confined Windows run would render as unsandboxed. "unknown" is this
@@ -311,19 +319,33 @@ func TestActiveMechanismsRestrictedToken(t *testing.T) {
 // isProcSelfSetNoNewPrivs is a plain function rather than a stubbable var, and inside a container
 // it can genuinely return RuntimeUnknown for an unrelated reason. It is asserted in
 // environment_windows_test.go instead, where every other detector is a hard-false stub.
-func TestGetContainerRuntimeRestrictedTokenIsUnknown(t *testing.T) {
-	origToken, origRead, origAttr, origExists, origLandlock, origChroot :=
-		isRestrictedToken, readFile, readProcAttr, fileExistsFunc, probeForLandlock, isChroot
+func TestGetContainerRuntimeWindowsTokenBitsAreUnknown(t *testing.T) {
+	origToken, origAppC, origRead, origAttr, origExists, origLandlock, origChroot :=
+		isRestrictedToken, isAppContainer, readFile, readProcAttr, fileExistsFunc, probeForLandlock, isChroot
 	t.Cleanup(func() {
-		isRestrictedToken, readFile, readProcAttr, fileExistsFunc, probeForLandlock, isChroot =
-			origToken, origRead, origAttr, origExists, origLandlock, origChroot
+		isRestrictedToken, isAppContainer, readFile, readProcAttr, fileExistsFunc, probeForLandlock, isChroot =
+			origToken, origAppC, origRead, origAttr, origExists, origLandlock, origChroot
 	})
 	readFile = func(string) ([]byte, error) { return nil, fmt.Errorf("file not found") }
 	readProcAttr = func(string) string { return "" }
 	fileExistsFunc = func(string) bool { return false }
 	probeForLandlock = func() (bool, error) { return false, nil }
 	isChroot = func() bool { return false }
-	isRestrictedToken = func() bool { return true }
 
-	assert.Equal(t, RuntimeUnknown, GetContainerRuntime(0, 0))
+	// Each bit alone must reach the badge. An AppContainer carries no restricting SIDs, so the
+	// restricted-token branch above it does not fire for a Copilot run — which is exactly the
+	// gap this case exists to hold shut.
+	for _, tt := range []struct {
+		name                     string
+		restricted, appContainer bool
+	}{
+		{"restricted token only", true, false},
+		{"app container only", false, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			isRestrictedToken = func() bool { return tt.restricted }
+			isAppContainer = func() bool { return tt.appContainer }
+			assert.Equal(t, RuntimeUnknown, GetContainerRuntime(0, 0))
+		})
+	}
 }

--- a/pkg/tasks/baseline/environment_windows_test.go
+++ b/pkg/tasks/baseline/environment_windows_test.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
 
-// The badge's false case: with no restricted token and nothing else present, Windows must
+// The badge's false case: with neither Windows token bit set and nothing else present, Windows must
 // report no runtime at all.
 //
 // Two of the detectors ahead of it are environment-sensitive even on Windows, and both had to
@@ -24,31 +26,81 @@ import (
 //
 // The remaining detectors really are hard-false stubs here — isSeatbelt, probeForLandlock,
 // isChroot and isProcSelfSetNoNewPrivs all come from the !darwin/!linux files — so with these
-// two pinned, isRestrictedToken is the only input left that can move the answer. That is what
-// makes this a regression guard: it fails if anyone later wires a second Windows signal into
-// the runtime chain without saying so.
-func TestGetContainerRuntimeRestrictedTokenOnWindows(t *testing.T) {
-	origToken, origRead, origExists := isRestrictedToken, readFile, fileExistsFunc
-	t.Cleanup(func() { isRestrictedToken, readFile, fileExistsFunc = origToken, origRead, origExists })
+// two pinned, the two token bools are the only inputs left that can move the answer. That is
+// what makes this a regression guard: it fails if anyone later wires a third Windows signal
+// into the runtime chain without saying so.
+func TestGetContainerRuntimeWindowsTokenBitsOnWindows(t *testing.T) {
+	origToken, origAppC, origRead, origExists := isRestrictedToken, isAppContainer, readFile, fileExistsFunc
+	t.Cleanup(func() {
+		isRestrictedToken, isAppContainer, readFile, fileExistsFunc = origToken, origAppC, origRead, origExists
+	})
 	readFile = func(string) ([]byte, error) { return nil, fmt.Errorf("file not found") }
 	fileExistsFunc = func(string) bool { return false }
 	t.Setenv("container", "")
 
 	for _, tt := range []struct {
-		name       string
-		restricted bool
-		want       ContainerRuntime
+		name                     string
+		restricted, appContainer bool
+		want                     ContainerRuntime
 	}{
-		{"restricted token", true, RuntimeUnknown},
-		{"unrestricted token", false, RuntimeNotFound},
+		{"neither", false, false, RuntimeNotFound},
+		{"restricted token", true, false, RuntimeUnknown},
+		{"app container", false, true, RuntimeUnknown},
+		{"both", true, true, RuntimeUnknown},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			isRestrictedToken = func() bool { return tt.restricted }
+			isAppContainer = func() bool { return tt.appContainer }
 			assert.Equal(t, tt.want, GetContainerRuntime(0, 0),
 				"container=%q — a non-empty value here promotes the answer to RuntimeUnknown",
 				os.Getenv("container"))
 		})
 	}
+}
+
+// tokenIsAppContainer is a hand-written constant because x/sys/windows does not export it.
+// This checks it against x/sys's own enum, which stops one value earlier at TokenLogonSid.
+//
+// Two independent sources have to agree: the literal is TokenIsAppContainer from winnt.h, and
+// TokenLogonSid+1 is where x/sys's iota run puts it. If a future x/sys inserts a class into
+// that run, this fails rather than the probe silently querying a different token property and
+// reading its result as a boolean.
+func TestTokenIsAppContainerMatchesTheXSysEnum(t *testing.T) {
+	assert.Equal(t, windows.TokenLogonSid+1, tokenIsAppContainer,
+		"TOKEN_INFORMATION_CLASS 29 is one past TokenLogonSid; x/sys has moved the enum")
+}
+
+// The false-positive guard for the AppContainer detector, against the real API rather than a
+// mock of it.
+//
+// The Go test binary is an ordinary console process, so it is not in an AppContainer, and the
+// detector must say so. This is weaker than the UAC guard below only because AppContainer has
+// no near-miss artefact to hand: nothing on a normal desktop resembles one. That is also the
+// reason the detector is safe, and this pins the claim on a real Windows runner.
+//
+// The raw query is repeated here rather than only calling isAppContainerImpl, because that
+// function swallows an error to false. Asserting on it alone would pass identically whether the
+// class number is right and the answer is genuinely false, or the call failed outright and
+// nothing was measured — the same absent-versus-empty confusion the findings themselves avoid.
+// Requiring the syscall to succeed is what proves tokenIsAppContainer names a real class and
+// that the probe can read it on this OS.
+func TestIsAppContainerFalseForAnOrdinaryProcess(t *testing.T) {
+	var tok windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &tok); err != nil {
+		t.Fatalf("OpenProcessToken: %v", err)
+	}
+	defer func() { _ = tok.Close() }()
+
+	var isAppC, retLen uint32
+	err := windows.GetTokenInformation(tok, tokenIsAppContainer,
+		(*byte)(unsafe.Pointer(&isAppC)), uint32(unsafe.Sizeof(isAppC)), &retLen)
+	require.NoError(t, err,
+		"TokenIsAppContainer (class %d) must be a queryable class on this Windows build", tokenIsAppContainer)
+	assert.Equal(t, uint32(4), retLen, "TokenIsAppContainer yields a DWORD")
+	assert.Zero(t, isAppC, "the test process is not in an AppContainer")
+
+	assert.False(t, isAppContainerImpl(),
+		"the test process is not sandboxed by MXC, so it must not report an app container")
 }
 
 // The false-positive guard against the real artefact, not a mock of it.

--- a/pkg/tasks/baseline/token.go
+++ b/pkg/tasks/baseline/token.go
@@ -3,11 +3,16 @@
 
 package tasks
 
-// A restricted token is a Windows access-token concept with no analogue elsewhere.
+// A restricted token and an AppContainer are Windows access-token concepts with no analogue
+// elsewhere.
 //
-// The var exists on every platform, not just Windows, so the seam is stubbable from tests
+// The vars exist on every platform, not just Windows, so the seams are stubbable from tests
 // that carry no build tag — which is what lets the false-positive table in
 // environment_test.go run on Linux and macOS too. Same shape as proc.go and landlock.go.
 var isRestrictedToken = isRestrictedTokenImpl
 
 func isRestrictedTokenImpl() bool { return false }
+
+var isAppContainer = isAppContainerImpl
+
+func isAppContainerImpl() bool { return false }

--- a/pkg/tasks/baseline/token_windows.go
+++ b/pkg/tasks/baseline/token_windows.go
@@ -4,9 +4,20 @@
 package tasks
 
 import (
+	"unsafe"
+
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sys/windows"
 )
+
+// tokenIsAppContainer is TokenIsAppContainer, TOKEN_INFORMATION_CLASS 29 in winnt.h.
+//
+// x/sys/windows does not declare it. It declares the same enum as an iota run and stops one
+// short, at TokenLogonSid (28), so the value has to be written out here. The literal is the
+// documented one; TestTokenIsAppContainerMatchesTheXSysEnum checks it against
+// windows.TokenLogonSid+1, so the two sources have to agree and a future x/sys that inserts a
+// class fails the test instead of silently querying the wrong thing.
+const tokenIsAppContainer = 29
 
 var isRestrictedToken = isRestrictedTokenImpl
 
@@ -46,4 +57,52 @@ func isRestrictedTokenImpl() bool {
 		return false
 	}
 	return restricted
+}
+
+var isAppContainer = isAppContainerImpl
+
+// isAppContainerImpl reports whether this process runs inside an AppContainer — the primitive
+// behind GitHub Copilot CLI's Windows sandbox, which is Microsoft Execution Containers (MXC)
+// on its ProcessContainer backend.
+//
+// MXC's Windows backend calls Experimental_CreateProcessInSandbox in processmodel.dll, driven
+// by a SandboxSpec whose app_container field its BaseContainerRunner always sets true. The
+// spec's other controls are policy the caller chooses — UI restrictions via JOB_OBJECT_UILIMIT
+// flags, the win32k system-call mitigation, least-privilege, integrity level — so each of them
+// can be off in a real sandbox and none is safe to key off. The AppContainer is the one thing
+// that is always there, so it is the one thing this reads.
+//
+// A mechanism and not a wrapper name, for the same reason isRestrictedTokenImpl is: an
+// AppContainer token cannot say who created it. Store apps, Chromium's renderer and Defender
+// Application Guard all produce one. Naming Copilot from this bit would repeat the
+// `srt (linux)` mistake.
+//
+// The false-positive risk is lower than the restricted-token detector's, not higher. A
+// restricted token is nearly the shape of an ordinary UAC split token, which is why that
+// detector needed care. An AppContainer has no ambient analogue at all: a normal console
+// process on a normal desktop is not in one, and only something that deliberately built an
+// AppContainer can put the probe inside it.
+//
+// A real TOKEN_QUERY handle rather than the GetCurrentProcessToken pseudo-handle, matching
+// isRestrictedTokenImpl. Errors swallow to false: on a Windows old enough to have no
+// AppContainers the call fails with ERROR_INVALID_PARAMETER, and false is the true answer
+// there anyway.
+func isAppContainerImpl() bool {
+	var tok windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &tok); err != nil {
+		log.Warn().Err(err).Msg("OpenProcessToken failed; reporting no app container")
+		return false
+	}
+	defer func() { _ = tok.Close() }()
+
+	// TokenIsAppContainer yields a DWORD, non-zero inside an AppContainer.
+	var isAppC uint32
+	var retLen uint32
+	err := windows.GetTokenInformation(tok, tokenIsAppContainer,
+		(*byte)(unsafe.Pointer(&isAppC)), uint32(unsafe.Sizeof(isAppC)), &retLen)
+	if err != nil {
+		log.Warn().Err(err).Msg("TokenIsAppContainer query failed; reporting no app container")
+		return false
+	}
+	return isAppC != 0
 }


### PR DESCRIPTION
## Summary

The probe had one Windows signal, `restricted-token`, which sees Codex CLI's sandbox. It does not see GitHub Copilot CLI's. A demonstrably confined run on a Windows 11 host emitted `sandbox_detection: []` and matched the unconfined run beside it, so the pair proved nothing.

Copilot's sandbox is Microsoft Execution Containers (MXC). Its Windows backend is called ProcessContainer, but it is not a Server Silo. MXC calls `Experimental_CreateProcessInSandbox` in `processmodel.dll` with a `SandboxSpec` whose `app_container` field its `BaseContainerRunner` always sets true. The isolation is an **AppContainer**.

This adds `app-container` as a second Windows mechanism, read from `TokenIsAppContainer`. It reuses the existing `token.go` / `token_windows.go` seam rather than adding files, because it is the same kind of fact: what this process's access token says about its own confinement.

## Why exactly one bit

Every other control in the `SandboxSpec` is policy the caller chooses, so its absence would prove nothing:

| spec field | observable as | usable? |
| :--- | :--- | :--- |
| `app_container` | `TokenIsAppContainer` | **yes — always true** |
| `ui_restrictions` | `JOB_OBJECT_UILIMIT_*` | no |
| `disallow_win32k_system_calls` | mitigation policy | no |
| `least_privilege` | stripped privileges | no, and UAC-shaped |
| integrity level | `TokenIntegrityLevel` | no |

`least_privilege` deserves the note: it produces the deny-only groups and stripped privileges ADR 0004 already rejected, because an ordinary non-elevated administrator's UAC split token is identical on both.

## Decisions worth reviewing

- **Two values, not one.** `restricted-token` and `app-container` stay separate rather than collapsing into `windows-sandbox`. The primitives are independent — MXC builds an AppContainer without `CreateRestrictedToken`, Codex builds a restricted token without an AppContainer — so keeping them apart is what lets the published data tell the two vendors' Windows sandboxes apart.
- **A mechanism, never a badge.** An AppContainer token cannot say who created it. Store apps, Chromium's renderer and Defender Application Guard all produce one.
- **`GetContainerRuntime` needs its own line**, not an extension of the restricted-token branch. An AppContainer carries no restricting SIDs, so `IsTokenRestricted` is false inside one and the existing branch does not fire.

## The constant

`TokenIsAppContainer` is `TOKEN_INFORMATION_CLASS` 29 and `x/sys/windows` does not export it — its iota run stops one short at `TokenLogonSid`. The literal is written out, and a test pins it against `windows.TokenLogonSid+1`, so two independent sources have to agree. A future `x/sys` that inserts a class fails the test instead of the probe silently querying a different property.

## What is verified, and what is not

Verified: builds and vets for `windows/amd64`, `linux/amd64` and `darwin/arm64`; `go test ./...` passes; the portable table covers all four combinations of the two token bools, proving each mechanism is a pure function of its own bit.

`TestIsAppContainerFalseForAnOrdinaryProcess` asserts the syscall **succeeds** rather than only that the answer is false. Asserting on `isAppContainerImpl` alone would pass identically whether the class number is right or the call failed outright — the same absent-versus-empty confusion the findings themselves avoid.

**Not verified: the positive case against a live MXC ProcessContainer.** The evidence that `app_container` is always set is MXC's own source, not a measurement. controlplaneio/sandbox-probe-reports#23 adds the `windows/copilot-sandbox` row that closes this; it is deliberately `optional` until it runs green.

See ADR 0005.
