### PR TITLE
feat(filesystem): split writeable paths by whether a write can persist

### DIFF
--- a/pkg/tasks/baseline.go
+++ b/pkg/tasks/baseline.go
@@ -98,7 +98,7 @@ func (t *PathTask) Run(ctx context.Context, ti Inputs) ([]*reportv1.Finding, err
 	}
 
 	log.Info().Str("task", t.GetName()).Msg("Filesystem enumeration task completed successfully")
-	return []*reportv1.Finding{
+	findings := []*reportv1.Finding{
 		{
 			FindingType: WRITEABLEPATHS,
 			Task:        t.GetName(),
@@ -111,7 +111,27 @@ func (t *PathTask) Run(ctx context.Context, ti Inputs) ([]*reportv1.Finding, err
 			Description: "Readable sensitive paths",
 			Value:       readableValue,
 		},
-	}, nil
+	}
+
+	// Emitted ONLY when the mount table was readable. Without it nothing was attributed to a
+	// filesystem, and an empty list would read as "measured, nothing ephemeral" — the same
+	// absent-versus-empty confusion the named-pipe findings avoid. A host that hides its mounts
+	// says nothing here rather than something false.
+	if paths.MountsReadable {
+		ephemeralValue, err := structpb.NewValue(stringSliceToInterface(paths.EphemeralWritablePaths))
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to convert ephemeral writeable paths to protobuf value")
+			return nil, err
+		}
+		findings = append(findings, &reportv1.Finding{
+			FindingType: EPHEMERALWRITEABLEPATHS,
+			Task:        t.GetName(),
+			Description: "Writeable paths backed by a memory-only filesystem, where a write cannot persist",
+			Value:       ephemeralValue,
+		})
+	}
+
+	return findings, nil
 }
 
 // NetworkTask produces: EXTERNALHOSTDNSRESOLUTION, EXTERNALHOSTCONNECTIVITY, TCPPORTSOPEN, UDPPORTSOPEN

--- a/pkg/tasks/baseline/environment.go
+++ b/pkg/tasks/baseline/environment.go
@@ -475,25 +475,55 @@ const procMountInfo = "/proc/self/mountinfo"
 func GetHostMounts() ([]Mount, error) {
 	// An unreadable mount table is a restricted environment, not a failure: report nothing rather
 	// than raise a finding about the probe's own confinement.
+	mounts, ok := mountTable()
+	if !ok {
+		return []Mount{}, nil
+	}
+
+	res := make([]Mount, 0, len(mounts))
+
+	for _, m := range mounts {
+		if !isKernelPseudoFilesystem(m.FSType) {
+			res = append(res, m)
+		}
+	}
+
+	return res, nil
+}
+
+// mountTable is the seam every mount reader goes through. It returns the UNFILTERED table plus
+// whether /proc/self/mountinfo could be read at all.
+//
+// Two things the filtered GetHostMounts view cannot express, and both matter here.
+//
+// The readability bool keeps `absent != empty` intact for callers that derive a finding from the
+// mounts: a host with no readable mount table has measured nothing, and must not emit an empty
+// list that reads as measured-and-negative. GetHostMounts folds both into an empty slice, which is
+// right for reporting the mounts themselves and wrong for reasoning about a path's backing.
+//
+// The table is unfiltered because a pseudo-filesystem is still the mount that BACKS a path. Drop
+// it and the deepest-covering search below silently attributes that path to an ancestor mount of a
+// different type — an answer that is wrong rather than missing.
+var mountTable = mountTableImpl
+
+func mountTableImpl() ([]Mount, bool) {
 	data, err := readFile(procMountInfo)
 	if err != nil {
-		return []Mount{}, nil
+		return nil, false
 	}
 
 	var res []Mount
 
 	for _, m := range parseMountInfo(data) {
-		if !isKernelPseudoFilesystem(m.FSType) {
-			res = append(res, Mount{
-				Source: m.Source,
-				Target: m.MountPoint,
-				FSType: m.FSType,
-				Root:   m.Root,
-			})
-		}
+		res = append(res, Mount{
+			Source: m.Source,
+			Target: m.MountPoint,
+			FSType: m.FSType,
+			Root:   m.Root,
+		})
 	}
 
-	return res, nil
+	return res, true
 }
 
 // parseMountInfo parses /proc/self/mountinfo. Each line is fixed up to the mount options, then a

--- a/pkg/tasks/baseline/filesystem.go
+++ b/pkg/tasks/baseline/filesystem.go
@@ -218,6 +218,16 @@ var SystemWritePaths = platformSystemWritePaths
 type PathPermissions struct {
 	WritablePaths []string
 	ReadablePaths []string
+
+	// EphemeralWritablePaths is the subset of WritablePaths whose backing filesystem keeps its
+	// contents in memory, so a write there cannot persist or reach host content. See
+	// writeable_backing.go for the measurement that makes this necessary.
+	EphemeralWritablePaths []string
+
+	// MountsReadable records whether /proc/self/mountinfo could be read. Without it no path can be
+	// attributed to a filesystem, so EphemeralWritablePaths is unmeasured rather than empty and
+	// the caller must omit the finding entirely.
+	MountsReadable bool
 }
 
 // ScanTargetedPaths performs targeted security enumeration by checking
@@ -263,6 +273,13 @@ func scanTargetedPathsForHome(home string) *PathPermissions {
 				result.WritablePaths = append(result.WritablePaths, path)
 			}
 		}
+	}
+
+	// Attribute each writeable path to the filesystem that actually serves it. Done here rather
+	// than in the caller so the two lists are derived from one scan and cannot drift apart.
+	if mounts, ok := mountTable(); ok {
+		result.MountsReadable = true
+		result.EphemeralWritablePaths = ephemeralWriteablePaths(result.WritablePaths, mounts)
 	}
 
 	return result

--- a/pkg/tasks/baseline/writeable_backing.go
+++ b/pkg/tasks/baseline/writeable_backing.go
@@ -1,0 +1,127 @@
+package tasks
+
+import "strings"
+
+// Writeable paths are not all the same capability, and counting them as if they were makes a
+// sandbox look weaker than no sandbox at all.
+//
+// Measured on a GitHub runner, GitHub Copilot CLI's Linux sandbox (MXC's bubblewrap backend)
+// against the same runner unconfined:
+//
+//	unconfined   writeable_paths = [/opt]
+//	confined     writeable_paths = [/usr /dev /var /opt]
+//
+// The confined run reports FOUR. The writes are real — an actual create in /usr succeeds inside
+// that sandbox — so this is not a false positive that a stricter check would remove. What changed
+// is what /usr *is*. The sandbox builds a fresh tmpfs root and bind-mounts host content at the
+// CHILDREN only:
+//
+//	tmpfs     -> /            (tmpfs,  root=/newroot)
+//	/dev/root -> /usr/bin     (ext4,   root=/usr/bin)
+//	/dev/root -> /usr/lib     (ext4,   root=/usr/lib)
+//	/dev/root -> /opt/pipx_bin(ext4,   root=/opt/pipx_bin)
+//
+// There is no mount at /usr, /var or /opt themselves. They are bare directories on the sandbox's
+// own tmpfs, owned by the sandbox user, existing only as mount points. Writing to them writes to
+// memory that dies with the sandbox and cannot touch the host's /usr. The unconfined run's single
+// /opt is the real thing on disk.
+//
+// So the honest split is not "sandbox versus host" — the probe cannot attest who built a mount —
+// but PERSISTENT versus EPHEMERAL, which follows from the backing filesystem's type and is
+// kernel-attested from /proc/self/mountinfo on any host, sandboxed or not. Under that split the
+// same measurement reads the right way round: the sandbox takes persistent write access from one
+// path to none.
+
+// memoryBacked reports whether a filesystem type keeps its contents only in memory, so a write
+// that lands on it cannot outlive the mount or modify anything another mount exposes.
+//
+// devtmpfs is included and is not a special case: /dev inside the sandbox above is a synthesised
+// tmpfs with individual device nodes bound in, and a write to the directory itself is as ephemeral
+// as any other. Disk-backed overlays are deliberately absent — an overlay's upper layer persists,
+// so writes to it are not ephemeral even though a container may discard them later. That is a
+// lifecycle claim about the container, which this cannot attest.
+func memoryBacked(fstype string) bool {
+	switch fstype {
+	case "tmpfs", "ramfs", "devtmpfs":
+		return true
+	}
+
+	return false
+}
+
+// nonPersistentFS reports whether a write landing on this filesystem can leave nothing behind on
+// any real filesystem — either because the contents live only in memory, or because the kernel
+// synthesises them and a file cannot be created there at all.
+//
+// The second half is not a refinement, it is the same defect again. Measured in the same
+// comparison as above, /proc is reported writeable on BOTH sides:
+//
+//	unconfined  writeable_paths = [... /sys /proc /dev ...]
+//	confined    writeable_paths = [/usr /proc /dev /var]
+//
+// isWritable trusts access(2) for directories and never attempts a write (see filesystem_unix.go,
+// "Access above is sufficient"). Running as root, access() answers yes for /proc because the mode
+// bits allow it — while an actual create fails, because procfs has no backing store to create in.
+// Counting that as write access to the system overstates the capability exactly as counting the
+// sandbox's tmpfs scaffolding did.
+//
+// isKernelPseudoFilesystem is reused rather than a second list being written here: it already
+// enumerates the interfaces the kernel synthesises, and one list that two callers share cannot
+// drift out of step with itself.
+func nonPersistentFS(fstype string) bool {
+	return memoryBacked(fstype) || isKernelPseudoFilesystem(fstype)
+}
+
+// mountCovers reports whether mountPoint is at or above path.
+//
+// Compared by path component, never by raw string prefix: "/usr" must not be read as covering
+// "/usrlocal", which a plain strings.HasPrefix would do and which would attribute a path to the
+// wrong filesystem — silently, and only on hosts that happen to have such a directory.
+func mountCovers(mountPoint, path string) bool {
+	if mountPoint == path || mountPoint == "/" {
+		return true
+	}
+
+	return strings.HasPrefix(path, strings.TrimSuffix(mountPoint, "/")+"/")
+}
+
+// backingMount returns the mount that actually serves path: the deepest one at or above it.
+//
+// Depth decides, because mounts nest. /usr/bin bound over a tmpfs root covers /usr/bin, while the
+// root covers everything — and only the deeper of the two describes what a write to /usr/bin
+// touches. Returns false when no mount covers the path, which on a host with no readable mount
+// table is every path.
+func backingMount(path string, mounts []Mount) (Mount, bool) {
+	var best Mount
+	found := false
+
+	for _, m := range mounts {
+		if !mountCovers(m.Target, path) {
+			continue
+		}
+		if !found || len(m.Target) > len(best.Target) {
+			best, found = m, true
+		}
+	}
+
+	return best, found
+}
+
+// ephemeralWriteablePaths returns the subset of writeable whose backing filesystem cannot keep a
+// write — memory-only or kernel-synthesised — preserving the order it was given.
+//
+// A path whose backing mount cannot be identified is NOT reported as ephemeral. The claim this
+// finding makes is "a write here does not persist", and an unidentified mount does not support it;
+// staying silent is the recoverable error, claiming ephemerality wrongly is not.
+func ephemeralWriteablePaths(writeable []string, mounts []Mount) []string {
+	out := make([]string, 0, len(writeable))
+
+	for _, p := range writeable {
+		m, ok := backingMount(p, mounts)
+		if ok && nonPersistentFS(m.FSType) {
+			out = append(out, p)
+		}
+	}
+
+	return out
+}

--- a/pkg/tasks/baseline/writeable_backing_test.go
+++ b/pkg/tasks/baseline/writeable_backing_test.go
@@ -1,0 +1,171 @@
+package tasks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The mount table measured inside GitHub Copilot CLI's Linux sandbox (MXC's bubblewrap backend) on
+// a GitHub runner, reduced to the entries that decide the answer. A tmpfs root with host content
+// bind-mounted at the CHILDREN, and nothing mounted at /usr, /var or /opt themselves.
+func copilotSandboxMounts() []Mount {
+	return []Mount{
+		{Source: "tmpfs", Target: "/", FSType: "tmpfs", Root: "/newroot"},
+		{Source: "/dev/root", Target: "/usr/bin", FSType: "ext4", Root: "/usr/bin"},
+		{Source: "/dev/root", Target: "/usr/lib", FSType: "ext4", Root: "/usr/lib"},
+		{Source: "/dev/root", Target: "/opt/pipx_bin", FSType: "ext4", Root: "/opt/pipx_bin"},
+		{Source: "tmpfs", Target: "/dev", FSType: "tmpfs", Root: "/"},
+		{Source: "/dev/root", Target: "/home/runner/work", FSType: "ext4", Root: "/home/runner/work"},
+	}
+}
+
+// The same runner unconfined: one real disk filesystem at the root.
+func unconfinedMounts() []Mount {
+	return []Mount{
+		{Source: "/dev/root", Target: "/", FSType: "ext4", Root: "/"},
+		{Source: "tmpfs", Target: "/dev/shm", FSType: "tmpfs", Root: "/"},
+		{Source: "tmpfs", Target: "/run", FSType: "tmpfs", Root: "/"},
+	}
+}
+
+// The finding exists because the raw count moves the WRONG WAY under a sandbox: confined reports
+// four writeable paths against unconfined's one, which reads as the sandbox granting more write
+// access than no sandbox at all. Splitting by backing filesystem puts it right — every one of the
+// confined four is memory-backed and cannot persist, so persistent write access goes 1 -> 0.
+//
+// This is the regression guard for the whole change: if it fails, the published comparison has
+// gone back to being misleading.
+func TestSandboxWriteablePathsAreEphemeralAndUnconfinedOnesAreNot(t *testing.T) {
+	confined := []string{"/usr", "/dev", "/var", "/opt"}
+	unconfined := []string{"/opt"}
+
+	gotConfined := ephemeralWriteablePaths(confined, copilotSandboxMounts())
+	assert.Equal(t, confined, gotConfined,
+		"every writeable path in the sandbox sits on its tmpfs root, so all four are ephemeral")
+
+	gotUnconfined := ephemeralWriteablePaths(unconfined, unconfinedMounts())
+	assert.Empty(t, gotUnconfined,
+		"/opt on a real ext4 root persists and must never be reported as ephemeral")
+
+	// The point of the split, stated as the assertion a reader cares about.
+	persistent := func(all, ephemeral []string) int { return len(all) - len(ephemeral) }
+	assert.Equal(t, 0, persistent(confined, gotConfined))
+	assert.Equal(t, 1, persistent(unconfined, gotUnconfined))
+}
+
+// Depth decides, not order: /usr/bin is bound over a tmpfs root, and only the deeper mount
+// describes what a write to /usr/bin actually touches.
+func TestBackingMountIsTheDeepestCoveringMount(t *testing.T) {
+	for _, tt := range []struct {
+		path       string
+		wantTarget string
+		wantFS     string
+	}{
+		{"/usr/bin", "/usr/bin", "ext4"},
+		{"/usr/bin/env", "/usr/bin", "ext4"},
+		{"/usr", "/", "tmpfs"},
+		{"/usr/share", "/", "tmpfs"},
+		{"/opt", "/", "tmpfs"},
+		{"/opt/pipx_bin", "/opt/pipx_bin", "ext4"},
+		{"/dev", "/dev", "tmpfs"},
+		{"/home/runner/work", "/home/runner/work", "ext4"},
+	} {
+		t.Run(tt.path, func(t *testing.T) {
+			m, ok := backingMount(tt.path, copilotSandboxMounts())
+			assert.True(t, ok, "the root mount covers everything, so a path must always resolve")
+			assert.Equal(t, tt.wantTarget, m.Target)
+			assert.Equal(t, tt.wantFS, m.FSType)
+		})
+	}
+}
+
+// The boundary a raw strings.HasPrefix gets wrong. "/usr" is not above "/usrlocal", and reading it
+// as though it were would attribute that path to the wrong filesystem — silently, and only on
+// hosts that happen to have such a directory, which is the worst way for a bug to behave.
+func TestMountCoversComparesPathComponentsNotStringPrefixes(t *testing.T) {
+	for _, tt := range []struct {
+		mountPoint, path string
+		want             bool
+	}{
+		{"/usr", "/usr", true},
+		{"/usr", "/usr/bin", true},
+		{"/usr", "/usrlocal", false},
+		{"/usr", "/usr-backup", false},
+		{"/", "/anything", true},
+		{"/", "/", true},
+		{"/usr/bin", "/usr", false},
+		{"/var/log", "/var/logrotate", false},
+	} {
+		t.Run(fmt.Sprintf("%s_covers_%s", tt.mountPoint, tt.path), func(t *testing.T) {
+			assert.Equal(t, tt.want, mountCovers(tt.mountPoint, tt.path))
+		})
+	}
+}
+
+// absent != empty. With no readable mount table nothing can be attributed to a filesystem, so the
+// scan must record that it measured nothing — and baseline.go omits the finding entirely rather
+// than publishing an empty list that reads as "measured, nothing ephemeral".
+func TestEphemeralIsUnmeasuredWhenTheMountTableCannotBeRead(t *testing.T) {
+	orig := mountTable
+	t.Cleanup(func() { mountTable = orig })
+
+	mountTable = func() ([]Mount, bool) { return nil, false }
+	got := scanTargetedPathsForHome(t.TempDir())
+	assert.False(t, got.MountsReadable,
+		"an unreadable mount table must be recorded, so the caller can omit the finding")
+	assert.Empty(t, got.EphemeralWritablePaths)
+
+	mountTable = func() ([]Mount, bool) { return unconfinedMounts(), true }
+	got = scanTargetedPathsForHome(t.TempDir())
+	assert.True(t, got.MountsReadable,
+		"a readable table means the answer is measured, even when nothing is ephemeral")
+}
+
+// A path no mount covers is not ephemeral. The finding claims "a write here does not persist", and
+// an unidentified backing filesystem does not support that claim.
+func TestUnattributablePathIsNotClaimedEphemeral(t *testing.T) {
+	noRoot := []Mount{{Source: "tmpfs", Target: "/dev", FSType: "tmpfs", Root: "/"}}
+
+	_, ok := backingMount("/opt", noRoot)
+	assert.False(t, ok, "no mount covers /opt when the root itself is missing from the table")
+	assert.Empty(t, ephemeralWriteablePaths([]string{"/opt"}, noRoot),
+		"silence is recoverable; a wrong ephemerality claim is not")
+}
+
+// Disk-backed overlays are deliberately NOT ephemeral: an overlay's upper layer persists, and
+// whether a container later discards it is a lifecycle fact this cannot attest.
+func TestNonPersistentCoversMemoryAndSynthesisedFilesystems(t *testing.T) {
+	for fs, want := range map[string]bool{
+		// memory-backed: the write happens, and dies with the mount
+		"tmpfs":    true,
+		"ramfs":    true,
+		"devtmpfs": true,
+		// kernel-synthesised: access(2) can answer yes while a create cannot succeed at all
+		"proc":   true,
+		"sysfs":  true,
+		"cgroup": true,
+		"bpf":    true,
+		// real stores, where a write persists
+		"ext4":    false,
+		"overlay": false,
+		"xfs":     false,
+		"btrfs":   false,
+		"9p":      false,
+	} {
+		assert.Equal(t, want, nonPersistentFS(fs), "fstype %q", fs)
+	}
+}
+
+// /proc is reported writeable when the scan runs as root, because isWritable trusts access(2) for
+// directories and never attempts a create. It must not count as persistent write access: procfs
+// has no backing store, so the create it implies would fail.
+func TestProcIsNotPersistentWriteAccess(t *testing.T) {
+	mounts := []Mount{
+		{Source: "/dev/root", Target: "/", FSType: "ext4", Root: "/"},
+		{Source: "proc", Target: "/proc", FSType: "proc", Root: "/"},
+	}
+	assert.Equal(t, []string{"/proc"}, ephemeralWriteablePaths([]string{"/etc", "/proc"}, mounts),
+		"/etc persists and /proc cannot")
+}

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -27,6 +27,7 @@ func (t *baseTask) GetDescription() string {
 
 const (
 	WRITEABLEPATHS            = "writeable_paths"
+	EPHEMERALWRITEABLEPATHS   = "ephemeral_writeable_paths"
 	SENSITIVEREADABLEPATHS    = "sensitive_readable_paths"
 	EXTERNALHOSTDNSRESOLUTION = "external_host_dns_resolution"
 	EXTERNALHOSTCONNECTIVITY  = "external_host_connectivity"
@@ -87,6 +88,7 @@ const (
 
 var expectedTypes = map[string]reflect.Type{
 	WRITEABLEPATHS:            reflect.TypeOf([]string{}),
+	EPHEMERALWRITEABLEPATHS:   reflect.TypeOf([]string{}),
 	SENSITIVEREADABLEPATHS:    reflect.TypeOf([]string{}),
 	EXTERNALHOSTDNSRESOLUTION: reflect.TypeOf([]string{}),
 	EXTERNALHOSTCONNECTIVITY:  reflect.TypeOf([]string{}),


### PR DESCRIPTION
## The problem, from the published data

`writeable_paths` counts every writeable directory as the same capability. It is not, and the Copilot Linux row shows why — **the count moves the wrong way under confinement**:

| | `writeable_paths` |
| :--- | :--- |
| `linux/copilot` (unconfined) | `[/opt]` |
| `linux/copilot-sandbox` | `[/usr /dev /var /opt]` |

Four against one reads, on the site, as the sandbox granting *more* write access than no sandbox at all.

## It is not a false positive

A create in `/usr` genuinely succeeds inside that sandbox. I reproduced it against a non-sandboxed control on the same host:

```
tmpfs root + child binds        control (no sandbox)
/usr  access-WRITEABLE  WRITE-SUCCEEDED    /usr  access-no  write-failed
/dev  access-WRITEABLE  WRITE-SUCCEEDED    /dev  access-no  write-failed
```

So no stricter write test removes this. What changed is **what `/usr` is**. The sandbox builds a fresh tmpfs root and bind-mounts host content at the **children** only:

```
tmpfs     -> /             (tmpfs, root=/newroot)
/dev/root -> /usr/bin      (ext4,  root=/usr/bin)
/dev/root -> /usr/lib      (ext4,  root=/usr/lib)
/dev/root -> /opt/pipx_bin (ext4,  root=/opt/pipx_bin)
```

There is **no mount at `/usr`, `/var` or `/opt`**. They are bare directories on the sandbox's own tmpfs, existing only as mount points. Writes there die with the sandbox and cannot touch the host's `/usr`. The unconfined `/opt` is the real thing on disk.

(My first hypothesis — that userns uid-0 mapping faked it — was **wrong**, and the control disproves it: userns-root still cannot write host-root-owned directories.)

## The fix

Add `ephemeral_writeable_paths`: the subset whose backing filesystem cannot keep a write.

The split is **persistent versus ephemeral**, not sandbox versus host. The probe cannot attest who built a mount, but it can attest the backing filesystem from `/proc/self/mountinfo` on any host, sandboxed or not. Under that split the same measurement reads the right way round.

`writeable_paths` itself is unchanged, so the existing time series survives.

## The same defect, found again by the fix

`/proc` is reported writeable on **both** sides when the scan runs as root. `isWritable` trusts `access(2)` for directories and never attempts a create:

```go
// Directories cannot be opened with O_WRONLY; Access above is sufficient.
if info.IsDir() { return true }
```

`access()` answers yes on the mode bits; procfs has no backing store to create in. `nonPersistentFS` reuses the existing `isKernelPseudoFilesystem` list rather than writing a second one that could drift.

## Verified against the real sandbox

Reproduced in a container running the actual Copilot launcher:

| | writeable | ephemeral | **persistent** |
| :--- | ---: | ---: | ---: |
| unconfined | 16 | 3 | **13** |
| confined | 4 | 4 | **0** |

## Correctness details worth reviewing

- **`absent != empty`.** The finding is emitted **only** when `/proc/self/mountinfo` was readable. A host that hides its mounts says nothing, rather than publishing an empty list that reads as measured-and-negative. `mountTable` carries that signal; `GetHostMounts` keeps its existing contract.
- **Unfiltered mount table** for backing resolution. A filtered-out pseudo-filesystem still *backs* a path; dropping it would attribute the path to an ancestor mount of a different type — wrong rather than missing.
- **Path components, not string prefixes.** `/usr` must not be read as covering `/usrlocal`. A `strings.HasPrefix` would misattribute silently, and only on hosts that happen to have such a directory.
- **Deepest covering mount wins**, because mounts nest.
- **Overlays are not ephemeral.** An overlay's upper layer persists; whether a container later discards it is a lifecycle claim this cannot attest.

## Tests

Six portable tests, no build tag. The headline one is the regression guard for the whole change: if it fails, the published comparison has gone back to being misleading.

`go test ./...` passes. `go vet` clean on linux/amd64, windows/amd64 and darwin/arm64. `gofmt` clean.

## Follow-up, not in this PR

The site needs a release and a pin bump before it can show the split. Once that lands, `linux/copilot-sandbox` stops reading as more permissive than unconfined.